### PR TITLE
feat(web): add guided operator workflow

### DIFF
--- a/apps/web/src/app/api/operator/workflow/route.js
+++ b/apps/web/src/app/api/operator/workflow/route.js
@@ -1,0 +1,46 @@
+import {
+  loadOperatorWorkflow,
+  performOperatorAction,
+  publicOperatorError,
+} from "../../../../server/operator-workflow.mjs";
+
+export const dynamic = "force-dynamic";
+
+function errorResponse(error) {
+  const failure = publicOperatorError(error);
+  return Response.json({ error: failure.error }, { status: failure.status });
+}
+
+export async function GET(request) {
+  const url = new URL(request.url);
+  try {
+    const snapshot = await loadOperatorWorkflow({
+      projectId: url.searchParams.get("project_id"),
+      corpusId: url.searchParams.get("corpus_id"),
+      contextId: url.searchParams.get("context_id"),
+      capsuleId: url.searchParams.get("context_capsule_id"),
+    });
+    return Response.json(snapshot, { headers: { "Cache-Control": "no-store" } });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function POST(request) {
+  let input;
+  try {
+    input = await request.json();
+  } catch {
+    return Response.json(
+      { error: { code: "OPERATOR_JSON_INVALID", message: "The request body is invalid." } },
+      { status: 400 },
+    );
+  }
+  try {
+    return Response.json(await performOperatorAction(input), {
+      headers: { "Cache-Control": "no-store" },
+    });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/apps/web/src/app/layout.js
+++ b/apps/web/src/app/layout.js
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import "./styles.css";
 
 export const metadata = {
@@ -10,7 +11,7 @@ export default function RootLayout({ children }) {
     <html lang="en">
       <body>
         <header>
-          <strong>SOAIACORE P0</strong>
+          <Link className="brand" href="/">SOAIACORE P0</Link>
           <span>MOCK · SYNTHETIC DATA ONLY</span>
         </header>
         <main>{children}</main>

--- a/apps/web/src/app/page.js
+++ b/apps/web/src/app/page.js
@@ -9,7 +9,7 @@ export default function HomePage() {
         This interface submits synthetic runs through the server-side Web BFF. It never
         connects to PostgreSQL, Blob Storage, or a model provider.
       </p>
-      <Link className="button" href="/runs/new">Create a synthetic run</Link>
+      <Link className="button" href="/workflow">Open operator workflow</Link>
     </section>
   );
 }

--- a/apps/web/src/app/styles.css
+++ b/apps/web/src/app/styles.css
@@ -14,20 +14,27 @@ header {
   justify-content: space-between;
   padding: 1rem 2rem;
 }
+.brand { color: #e6edf7; font-weight: 800; text-decoration: none; }
 header span, .eyebrow { color: #75d7ff; font-size: .78rem; letter-spacing: .12em; }
-main { margin: 0 auto; max-width: 760px; padding: 4rem 1.5rem; }
+main { margin: 0 auto; max-width: 1180px; padding: 4rem 1.5rem; }
 h1 { font-size: clamp(2rem, 7vw, 4.5rem); line-height: 1; }
 h2 { margin-top: 2rem; }
 p { color: #b7c4d8; line-height: 1.7; }
 form { display: grid; gap: 1rem; }
 label { display: grid; gap: .45rem; }
-input {
+input, select {
   background: #101d30;
   border: 1px solid #334968;
   border-radius: .5rem;
   color: inherit;
   padding: .8rem;
+  width: 100%;
 }
+input:focus, select:focus, button:focus-visible, .button:focus-visible, .brand:focus-visible {
+  outline: 3px solid rgba(117, 215, 255, .35);
+  outline-offset: 2px;
+}
+input:disabled, select:disabled { cursor: not-allowed; opacity: .55; }
 .button, button {
   background: #52c7f5;
   border: 0;
@@ -39,8 +46,96 @@ input {
   padding: .8rem 1rem;
   text-decoration: none;
 }
+button:disabled { cursor: not-allowed; opacity: .5; }
 dl { display: grid; grid-template-columns: 10rem 1fr; gap: .6rem; }
 dt { color: #8fa3bf; }
 dd { margin: 0; }
 pre { background: #101d30; border-radius: .5rem; overflow: auto; padding: 1rem; }
+
+.workflow-shell { width: 100%; }
+.workflow-hero {
+  align-items: end;
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: minmax(0, 1fr) auto;
+  margin-bottom: 2rem;
+}
+.workflow-hero h1 { margin-bottom: 1rem; max-width: 13ch; }
+.workflow-hero p { max-width: 68ch; }
+.mode-badge {
+  background: linear-gradient(145deg, #10283a, #0b1b2c);
+  border: 1px solid #2f6f86;
+  border-radius: .8rem;
+  display: grid;
+  gap: .35rem;
+  min-width: 10rem;
+  padding: 1rem;
+}
+.mode-badge span { color: #8fa3bf; font-size: .72rem; letter-spacing: .08em; text-transform: uppercase; }
+.mode-badge strong { color: #79e5aa; font-size: 1.35rem; }
+.operator-workflow { display: grid; gap: 1rem; }
+.workflow-steps {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.workflow-card {
+  align-content: start;
+  background: #0d1929;
+  border: 1px solid #24334a;
+  border-radius: .9rem;
+  display: grid;
+  gap: 1rem;
+  padding: 1.25rem;
+}
+.workflow-card form { border-top: 1px solid #24334a; padding-top: 1rem; }
+.workflow-card h2, .workflow-card p { margin: 0; }
+.workflow-card button { justify-self: start; }
+.step-heading { align-items: start; display: flex; gap: .8rem; }
+.step-heading > span {
+  align-items: center;
+  background: #17324a;
+  border: 1px solid #2d607c;
+  border-radius: 999px;
+  color: #75d7ff;
+  display: inline-flex;
+  flex: 0 0 2rem;
+  font-weight: 800;
+  height: 2rem;
+  justify-content: center;
+}
+.step-heading div { display: grid; gap: .4rem; }
+.step-heading p { font-size: .92rem; }
+.technical-id { color: #8fa3bf; display: block; overflow-wrap: anywhere; }
+.technical-id code { color: #c5d5e9; }
+.empty-state, .validation-state, .immutability-note, .loading-panel {
+  border-radius: .6rem;
+  font-size: .9rem;
+  padding: .8rem;
+}
+.empty-state, .loading-panel { background: #101d30; border: 1px dashed #334968; }
+.validation-state { background: #351f18; border: 1px solid #825139; color: #ffd1b8; }
+.immutability-note { background: #14263a; border: 1px solid #2d607c; display: grid; gap: .25rem; }
+.immutability-note strong { color: #75d7ff; }
+.immutability-note span { color: #b7c4d8; }
+.notice { border-radius: .65rem; padding: .9rem 1rem; position: sticky; top: .75rem; z-index: 2; }
+.notice.error { background: #391c24; border: 1px solid #8e4354; color: #ffd1da; }
+.notice.success { background: #143025; border: 1px solid #397a5c; color: #bff3d3; }
+.final-step { border-color: #2f6f86; grid-column: 1 / -1; }
+.run-summary { background: #101d30; border-radius: .65rem; grid-template-columns: 8rem 1fr; margin: 0; padding: 1rem; }
+.primary-action { background: #79e5aa; font-size: 1rem; padding: 1rem 1.3rem; }
+
+@media (max-width: 760px) {
+  header { align-items: flex-start; flex-direction: column; gap: .5rem; padding: 1rem; }
+  main { padding: 2.5rem 1rem; }
+  .workflow-hero, .workflow-steps { grid-template-columns: 1fr; }
+  .workflow-hero { align-items: start; }
+  .mode-badge { width: 100%; }
+  .final-step { grid-column: auto; }
+  .run-summary, dl { grid-template-columns: 1fr; }
+  .run-summary dd, dd { margin-bottom: .5rem; }
+}
 

--- a/apps/web/src/app/workflow/error.js
+++ b/apps/web/src/app/workflow/error.js
@@ -1,0 +1,12 @@
+"use client";
+
+export default function WorkflowError({ reset }) {
+  return (
+    <section className="workflow-shell">
+      <p className="eyebrow">Operator workflow unavailable</p>
+      <h1>We could not load the workflow.</h1>
+      <p>The Core service may be temporarily unavailable. No data was submitted.</p>
+      <button type="button" onClick={() => reset()}>Try again</button>
+    </section>
+  );
+}

--- a/apps/web/src/app/workflow/loading.js
+++ b/apps/web/src/app/workflow/loading.js
@@ -1,0 +1,9 @@
+export default function WorkflowLoading() {
+  return (
+    <section className="workflow-shell" aria-busy="true">
+      <p className="eyebrow">Internal operator · MOCK only</p>
+      <h1>Loading workflow…</h1>
+      <div className="loading-panel">Reading available projects and analysis profiles.</div>
+    </section>
+  );
+}

--- a/apps/web/src/app/workflow/page.js
+++ b/apps/web/src/app/workflow/page.js
@@ -1,0 +1,27 @@
+import OperatorWorkflow from "./workflow-client";
+import { loadOperatorWorkflow } from "../../server/operator-workflow.mjs";
+
+export const dynamic = "force-dynamic";
+
+export default async function OperatorWorkflowPage() {
+  const initialData = await loadOperatorWorkflow();
+  return (
+    <section className="workflow-shell">
+      <div className="workflow-hero">
+        <div>
+          <p className="eyebrow">Internal operator · MOCK only</p>
+          <h1>Build a synthetic analysis run</h1>
+          <p>
+            Select or create each resource in order. Technical identifiers remain visible for
+            traceability, but the workflow never asks you to copy or type them.
+          </p>
+        </div>
+        <div className="mode-badge" aria-label="Provider mode MOCK">
+          <span>Provider mode</span>
+          <strong>MOCK</strong>
+        </div>
+      </div>
+      <OperatorWorkflow initialData={initialData} />
+    </section>
+  );
+}

--- a/apps/web/src/app/workflow/workflow-client.js
+++ b/apps/web/src/app/workflow/workflow-client.js
@@ -1,0 +1,289 @@
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+
+const EMPTY_SELECTION = {
+  projectId: "",
+  corpusId: "",
+  contextId: "",
+  capsuleId: "",
+};
+
+function requestId() {
+  return globalThis.crypto?.randomUUID?.() ?? `request-${Date.now()}`;
+}
+
+function selectedProfileKey(profile) {
+  return profile ? `${profile.analysis_profile_id}::${profile.version}` : "";
+}
+
+function technicalId(label, value) {
+  if (!value) return null;
+  return <small className="technical-id">{label}: <code>{value}</code></small>;
+}
+
+export default function OperatorWorkflow({ initialData }) {
+  const router = useRouter();
+  const [data, setData] = useState(initialData);
+  const [selection, setSelection] = useState(EMPTY_SELECTION);
+  const [profileKey, setProfileKey] = useState(selectedProfileKey(initialData.profiles[0]));
+  const [purpose, setPurpose] = useState("P1_SYNTHETIC_WEB");
+  const [busy, setBusy] = useState("");
+  const [notice, setNotice] = useState(null);
+  const operationKeys = useRef(new Map());
+
+  const project = data.projects.find((item) => item.project_id === selection.projectId);
+  const corpus = data.corpora.find((item) => item.corpus_id === selection.corpusId);
+  const context = data.contexts.find((item) => item.context_id === selection.contextId);
+  const capsule = data.capsules.find(
+    (item) => item.context_capsule_id === selection.capsuleId,
+  );
+  const profile = useMemo(
+    () => data.profiles.find((item) => selectedProfileKey(item) === profileKey),
+    [data.profiles, profileKey],
+  );
+
+  async function readSnapshot(nextSelection) {
+    setBusy("loading");
+    setNotice(null);
+    const query = new URLSearchParams();
+    if (nextSelection.projectId) query.set("project_id", nextSelection.projectId);
+    if (nextSelection.corpusId) query.set("corpus_id", nextSelection.corpusId);
+    if (nextSelection.contextId) query.set("context_id", nextSelection.contextId);
+    if (nextSelection.capsuleId) {
+      query.set("context_capsule_id", nextSelection.capsuleId);
+    }
+    try {
+      const response = await fetch(`/api/operator/workflow?${query}`, {
+        cache: "no-store",
+      });
+      const payload = await response.json();
+      if (!response.ok) throw new Error(payload?.error?.message ?? "Unable to load workflow.");
+      setData(payload);
+      setSelection(nextSelection);
+      const capsuleProfile = payload.selectedCapsule?.payload;
+      if (capsuleProfile?.analysis_profile_id && capsuleProfile?.analysis_profile_version) {
+        setProfileKey(
+          `${capsuleProfile.analysis_profile_id}::${capsuleProfile.analysis_profile_version}`,
+        );
+      }
+      return payload;
+    } catch (error) {
+      setNotice({ type: "error", text: error.message });
+      return null;
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function submitAction(action, values) {
+    const fingerprint = JSON.stringify(values);
+    const existing = operationKeys.current.get(action);
+    const key = existing?.fingerprint === fingerprint ? existing.key : requestId();
+    operationKeys.current.set(action, { fingerprint, key });
+    setBusy(action);
+    setNotice(null);
+    try {
+      const response = await fetch("/api/operator/workflow", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action, request_id: key, values }),
+      });
+      const payload = await response.json();
+      if (!response.ok) throw new Error(payload?.error?.message ?? "The operation failed.");
+      operationKeys.current.delete(action);
+      const replayed = payload.idempotencyReplayed ? " Replayed safely." : "";
+      const successNotice = { type: "success", text: `Saved successfully.${replayed}` };
+      const resource = payload.resource;
+      if (action === "create_run") {
+        router.push(`/runs/${encodeURIComponent(resource.run_id)}`);
+        return;
+      }
+      const nextSelection = { ...selection };
+      if (action === "create_project") {
+        Object.assign(nextSelection, {
+          projectId: resource.project_id,
+          corpusId: "",
+          contextId: "",
+          capsuleId: "",
+        });
+      } else if (action === "create_corpus") {
+        Object.assign(nextSelection, {
+          corpusId: resource.corpus_id,
+          contextId: "",
+          capsuleId: "",
+        });
+      } else if (action === "create_context") {
+        Object.assign(nextSelection, {
+          contextId: resource.context_id,
+          capsuleId: "",
+        });
+      } else if (action === "create_capsule") {
+        nextSelection.capsuleId = resource.context_capsule_id;
+      }
+      const refreshed = await readSnapshot(nextSelection);
+      if (refreshed) setNotice(successNotice);
+    } catch (error) {
+      setNotice({ type: "error", text: error.message });
+    } finally {
+      setBusy("");
+    }
+  }
+
+  const disabled = Boolean(busy);
+  const profileParts = profileKey.split("::");
+
+  return (
+    <div className="operator-workflow" aria-busy={disabled}>
+      {notice ? <div className={`notice ${notice.type}`} role={notice.type === "error" ? "alert" : "status"}>{notice.text}</div> : null}
+
+      <ol className="workflow-steps">
+        <li className="workflow-card">
+          <div className="step-heading"><span>1</span><div><h2>Project</h2><p>Choose an existing project or create a synthetic one.</p></div></div>
+          <label>
+            Existing project
+            <select
+              value={selection.projectId}
+              disabled={disabled}
+              onChange={(event) => readSnapshot({
+                projectId: event.target.value,
+                corpusId: "",
+                contextId: "",
+                capsuleId: "",
+              })}
+            >
+              <option value="">Select a project</option>
+              {data.projects.map((item) => <option key={item.project_id} value={item.project_id}>{item.name}</option>)}
+            </select>
+          </label>
+          {technicalId("Project ID", project?.project_id)}
+          {data.projects.length === 0 ? <p className="empty-state">No projects exist yet. Create the first synthetic project.</p> : null}
+          <form onSubmit={(event) => { event.preventDefault(); const form = new FormData(event.currentTarget); submitAction("create_project", { name: form.get("name") }); }}>
+            <label>New project name<input name="name" maxLength={200} required disabled={disabled} /></label>
+            <button type="submit" disabled={disabled}>{busy === "create_project" ? "Creating…" : "Create project"}</button>
+          </form>
+        </li>
+
+        <li className="workflow-card">
+          <div className="step-heading"><span>2</span><div><h2>Corpus</h2><p>Scope the synthetic material inside the selected project.</p></div></div>
+          <label>
+            Existing corpus
+            <select
+              value={selection.corpusId}
+              disabled={disabled || !selection.projectId}
+              onChange={(event) => readSnapshot({ ...selection, corpusId: event.target.value, contextId: "", capsuleId: "" })}
+            >
+              <option value="">Select a corpus</option>
+              {data.corpora.map((item) => <option key={item.corpus_id} value={item.corpus_id}>{item.name}</option>)}
+            </select>
+          </label>
+          {technicalId("Corpus ID", corpus?.corpus_id)}
+          {selection.projectId && data.corpora.length === 0 ? <p className="empty-state">This project has no corpora yet.</p> : null}
+          <form onSubmit={(event) => { event.preventDefault(); const form = new FormData(event.currentTarget); submitAction("create_corpus", { project_id: selection.projectId, name: form.get("name") }); }}>
+            <label>New corpus name<input name="name" maxLength={200} required disabled={disabled || !selection.projectId} /></label>
+            <button type="submit" disabled={disabled || !selection.projectId}>{busy === "create_corpus" ? "Creating…" : "Create corpus"}</button>
+          </form>
+        </li>
+
+        <li className="workflow-card">
+          <div className="step-heading"><span>3</span><div><h2>Context</h2><p>Describe the bounded synthetic context for this corpus.</p></div></div>
+          <label>
+            Existing context
+            <select
+              value={selection.contextId}
+              disabled={disabled || !selection.corpusId}
+              onChange={(event) => readSnapshot({ ...selection, contextId: event.target.value, capsuleId: "" })}
+            >
+              <option value="">Select a context</option>
+              {data.contexts.map((item) => <option key={item.context_id} value={item.context_id}>{item.dimensions?.label ?? item.context_type}</option>)}
+            </select>
+          </label>
+          {technicalId("Context ID", context?.context_id)}
+          {selection.corpusId && data.contexts.length === 0 ? <p className="empty-state">This corpus has no contexts yet.</p> : null}
+          <form onSubmit={(event) => { event.preventDefault(); const form = new FormData(event.currentTarget); submitAction("create_context", { project_id: selection.projectId, corpus_id: selection.corpusId, label: form.get("label") }); }}>
+            <label>New context label<input name="label" maxLength={200} required disabled={disabled || !selection.corpusId} /></label>
+            <button type="submit" disabled={disabled || !selection.corpusId}>{busy === "create_context" ? "Creating…" : "Create context"}</button>
+          </form>
+        </li>
+
+        <li className="workflow-card">
+          <div className="step-heading"><span>4</span><div><h2>Context capsule</h2><p>Select an immutable snapshot or create a new one.</p></div></div>
+          <div className="immutability-note"><strong>Immutable snapshot</strong><span>Changing context or profile data creates a new capsule; existing capsules are never edited.</span></div>
+          <label>
+            Existing capsule
+            <select
+              value={selection.capsuleId}
+              disabled={disabled || !selection.contextId}
+              onChange={(event) => readSnapshot({ ...selection, capsuleId: event.target.value })}
+            >
+              <option value="">Select a capsule</option>
+              {data.capsules.map((item) => <option key={item.context_capsule_id} value={item.context_capsule_id}>Snapshot · {item.created_at ?? item.schema_version}</option>)}
+            </select>
+          </label>
+          {technicalId("Capsule ID", capsule?.context_capsule_id)}
+          {capsule ? technicalId("Input hash", capsule.input_hash) : null}
+          {profile ? <small className="technical-id">New snapshots bind the profile <strong>{profile.name ?? profile.analysis_profile_id}</strong> selected in step 5.</small> : null}
+          {selection.contextId && data.capsules.length === 0 ? <p className="empty-state">No snapshots exist for this context.</p> : null}
+          <button
+            type="button"
+            disabled={disabled || !selection.contextId || !profile}
+            onClick={() => submitAction("create_capsule", {
+              project_id: selection.projectId,
+              corpus_id: selection.corpusId,
+              context_id: selection.contextId,
+              analysis_profile_id: profile?.analysis_profile_id,
+              analysis_profile_version: profile?.version,
+              purpose,
+            })}
+          >
+            {busy === "create_capsule" ? "Creating snapshot…" : "Create new immutable capsule"}
+          </button>
+        </li>
+
+        <li className="workflow-card">
+          <div className="step-heading"><span>5</span><div><h2>Analysis profile</h2><p>Choose the approved profile bound to this run.</p></div></div>
+          <label>
+            Analysis profile
+            <select value={profileKey} disabled={disabled || data.profiles.length === 0} onChange={(event) => setProfileKey(event.target.value)}>
+              {data.profiles.length === 0 ? <option value="">No profiles available</option> : null}
+              {data.profiles.map((item) => <option key={selectedProfileKey(item)} value={selectedProfileKey(item)}>{item.name ?? item.analysis_profile_id} · {item.version}</option>)}
+            </select>
+          </label>
+          {profile ? technicalId("Profile ID", `${profile.analysis_profile_id} · ${profile.version}`) : null}
+          {data.profiles.length === 0 ? <p className="empty-state">An approved AnalysisProfile must exist before a capsule or run can be created.</p> : null}
+          {data.selectedCapsule && profile && (
+            data.selectedCapsule.payload?.analysis_profile_id !== profile.analysis_profile_id ||
+            data.selectedCapsule.payload?.analysis_profile_version !== profile.version
+          ) ? <p className="validation-state">This profile differs from the immutable capsule. Create a new capsule before running.</p> : null}
+        </li>
+
+        <li className="workflow-card final-step">
+          <div className="step-heading"><span>6</span><div><h2>Run</h2><p>Queue the selected snapshot through the deterministic MOCK fixture.</p></div></div>
+          <label>Purpose<input value={purpose} maxLength={200} required disabled={disabled} onChange={(event) => setPurpose(event.target.value)} /></label>
+          <dl className="run-summary">
+            <dt>Project</dt><dd>{project?.name ?? "Not selected"}</dd>
+            <dt>Corpus</dt><dd>{corpus?.name ?? "Not selected"}</dd>
+            <dt>Context</dt><dd>{context?.dimensions?.label ?? "Not selected"}</dd>
+            <dt>Capsule</dt><dd>{capsule ? "Immutable snapshot selected" : "Not selected"}</dd>
+            <dt>Profile</dt><dd>{profile?.name ?? "Not selected"}</dd>
+            <dt>Mode</dt><dd>MOCK · documented-observation</dd>
+          </dl>
+          <button
+            className="primary-action"
+            type="button"
+            disabled={disabled || !capsule || !profile || !purpose.trim()}
+            onClick={() => submitAction("create_run", {
+              context_capsule_id: selection.capsuleId,
+              analysis_profile_id: profileParts[0],
+              analysis_profile_version: profileParts[1],
+              purpose,
+            })}
+          >
+            {busy === "create_run" ? "Queuing…" : "Queue MOCK run"}
+          </button>
+        </li>
+      </ol>
+    </div>
+  );
+}

--- a/apps/web/src/server/core-client.mjs
+++ b/apps/web/src/server/core-client.mjs
@@ -34,6 +34,7 @@ export async function coreRequest(
     method = "GET",
     body,
     idempotencyKey,
+    includeResponseMetadata = false,
     fetchImpl = globalThis.fetch,
     environment = process.env,
   } = {},
@@ -71,6 +72,12 @@ export async function coreRequest(
       response.status,
       error.details ?? {},
     );
+  }
+  if (includeResponseMetadata) {
+    return {
+      data: payload,
+      idempotencyReplayed: response.headers.get("Idempotency-Replayed") === "true",
+    };
   }
   return payload;
 }

--- a/apps/web/src/server/operator-workflow.mjs
+++ b/apps/web/src/server/operator-workflow.mjs
@@ -1,0 +1,266 @@
+import { randomUUID } from "node:crypto";
+
+import { CoreApiError, coreRequest } from "./core-client.mjs";
+
+const ACTIONS = new Set([
+  "create_project",
+  "create_corpus",
+  "create_context",
+  "create_capsule",
+  "create_run",
+]);
+const REQUEST_ID_PATTERN = /^[A-Za-z0-9_-]{8,100}$/;
+const PROFILE_ID_PATTERN = /^AP-[0-9]{3}$/;
+
+export class OperatorValidationError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = "OperatorValidationError";
+    this.code = code;
+    this.status = 400;
+  }
+}
+
+function requiredText(value, label, maxLength = 200) {
+  const text = String(value ?? "").trim();
+  if (!text) {
+    throw new OperatorValidationError("OPERATOR_INPUT_REQUIRED", `${label} is required.`);
+  }
+  if (text.length > maxLength) {
+    throw new OperatorValidationError(
+      "OPERATOR_INPUT_TOO_LONG",
+      `${label} must be ${maxLength} characters or fewer.`,
+    );
+  }
+  return text;
+}
+
+function optionalIdentifier(value, label) {
+  const text = String(value ?? "").trim();
+  if (!text || text.length > 200 || !/^[A-Za-z0-9_.:-]+$/.test(text)) {
+    throw new OperatorValidationError("OPERATOR_SELECTION_INVALID", `${label} is invalid.`);
+  }
+  return text;
+}
+
+function resourceId(prefix, uuidImpl) {
+  return `${prefix}_${uuidImpl().replaceAll("-", "")}`;
+}
+
+export function workflowIdempotencyKey(action, requestId) {
+  if (!ACTIONS.has(action)) {
+    throw new OperatorValidationError("OPERATOR_ACTION_INVALID", "The requested action is invalid.");
+  }
+  const normalized = String(requestId ?? "").trim();
+  if (!REQUEST_ID_PATTERN.test(normalized)) {
+    throw new OperatorValidationError(
+      "OPERATOR_REQUEST_ID_INVALID",
+      "The operation request identifier is invalid.",
+    );
+  }
+  return `web-${action}-${normalized}`;
+}
+
+function queryPath(path, values) {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(values)) {
+    if (value) query.set(key, value);
+  }
+  query.set("limit", "100");
+  return `${path}?${query}`;
+}
+
+export async function loadOperatorWorkflow(
+  selection = {},
+  { coreRequestImpl = coreRequest } = {},
+) {
+  const projectId = String(selection.projectId ?? "").trim();
+  const corpusId = String(selection.corpusId ?? "").trim();
+  const contextId = String(selection.contextId ?? "").trim();
+  const capsuleId = String(selection.capsuleId ?? "").trim();
+
+  const [projects, profiles] = await Promise.all([
+    coreRequestImpl("/v1/projects?limit=100"),
+    coreRequestImpl("/v1/analysis-profiles?limit=100"),
+  ]);
+  const corpora = projectId
+    ? await coreRequestImpl(
+        `/v1/projects/${encodeURIComponent(projectId)}/corpora?limit=100`,
+      )
+    : [];
+  const contexts = projectId
+    ? await coreRequestImpl(
+        queryPath("/v1/contexts", { project_id: projectId, corpus_id: corpusId }),
+      )
+    : [];
+  const capsules = contextId
+    ? await coreRequestImpl(
+        queryPath("/v1/context-capsules", { context_id: contextId }),
+      )
+    : [];
+  const selectedCapsule = capsuleId
+    ? await coreRequestImpl(`/v1/context-capsules/${encodeURIComponent(capsuleId)}`)
+    : null;
+
+  return { projects, corpora, contexts, capsules, profiles, selectedCapsule };
+}
+
+async function writeCore(coreRequestImpl, path, method, body, idempotencyKey) {
+  const result = await coreRequestImpl(path, {
+    method,
+    body,
+    idempotencyKey,
+    includeResponseMetadata: true,
+  });
+  return {
+    resource: result.data,
+    idempotencyReplayed: result.idempotencyReplayed,
+  };
+}
+
+export async function performOperatorAction(
+  input,
+  { coreRequestImpl = coreRequest, uuidImpl = randomUUID } = {},
+) {
+  const action = String(input?.action ?? "");
+  const idempotencyKey = workflowIdempotencyKey(action, input?.request_id);
+  const values = input?.values ?? {};
+
+  if (action === "create_project") {
+    const projectId = resourceId("prj", uuidImpl);
+    return writeCore(
+      coreRequestImpl,
+      `/v1/projects/${projectId}`,
+      "PUT",
+      {
+        name: requiredText(values.name, "Project name"),
+        status: "ACTIVE",
+        metadata: { synthetic: true, source: "P1_WEB_OPERATOR" },
+      },
+      idempotencyKey,
+    );
+  }
+
+  if (action === "create_corpus") {
+    const projectId = optionalIdentifier(values.project_id, "Project selection");
+    const corpusId = resourceId("cor", uuidImpl);
+    return writeCore(
+      coreRequestImpl,
+      `/v1/projects/${encodeURIComponent(projectId)}/corpora/${corpusId}`,
+      "PUT",
+      {
+        name: requiredText(values.name, "Corpus name"),
+        metadata: { synthetic: true, source: "P1_WEB_OPERATOR" },
+      },
+      idempotencyKey,
+    );
+  }
+
+  if (action === "create_context") {
+    const projectId = optionalIdentifier(values.project_id, "Project selection");
+    const corpusId = optionalIdentifier(values.corpus_id, "Corpus selection");
+    const contextId = resourceId("ctx", uuidImpl);
+    return writeCore(
+      coreRequestImpl,
+      "/v1/contexts",
+      "POST",
+      {
+        context_id: contextId,
+        project_id: projectId,
+        context_type: "P1_SYNTHETIC_OPERATOR",
+        dimensions: {
+          corpus_id: corpusId,
+          label: requiredText(values.label, "Context label"),
+          synthetic: true,
+        },
+      },
+      idempotencyKey,
+    );
+  }
+
+  const profileId = optionalIdentifier(values.analysis_profile_id, "Analysis profile");
+  const profileVersion = requiredText(values.analysis_profile_version, "Profile version", 100);
+  if (!PROFILE_ID_PATTERN.test(profileId)) {
+    throw new OperatorValidationError(
+      "OPERATOR_PROFILE_INVALID",
+      "The selected analysis profile is invalid.",
+    );
+  }
+
+  if (action === "create_capsule") {
+    const projectId = optionalIdentifier(values.project_id, "Project selection");
+    const corpusId = optionalIdentifier(values.corpus_id, "Corpus selection");
+    const contextId = optionalIdentifier(values.context_id, "Context selection");
+    const capsuleId = resourceId("cap", uuidImpl);
+    return writeCore(
+      coreRequestImpl,
+      "/v1/context-capsules",
+      "POST",
+      {
+        context_capsule_id: capsuleId,
+        context_id: contextId,
+        schema_version: "P0-RUNTIME-1",
+        payload: {
+          project_id: projectId,
+          corpus_id: corpusId,
+          context_id: contextId,
+          analysis_profile_id: profileId,
+          analysis_profile_version: profileVersion,
+          identity_refs: [],
+          evidence_refs: [],
+          synthetic_only: true,
+          purpose: requiredText(values.purpose, "Purpose"),
+        },
+      },
+      idempotencyKey,
+    );
+  }
+
+  const capsuleId = optionalIdentifier(values.context_capsule_id, "Context capsule");
+  const capsule = await coreRequestImpl(
+    `/v1/context-capsules/${encodeURIComponent(capsuleId)}`,
+  );
+  if (
+    capsule?.payload?.analysis_profile_id !== profileId ||
+    capsule?.payload?.analysis_profile_version !== profileVersion
+  ) {
+    throw new OperatorValidationError(
+      "OPERATOR_CAPSULE_PROFILE_MISMATCH",
+      "The selected profile differs from the immutable capsule. Create a new capsule for this profile.",
+    );
+  }
+  return writeCore(
+    coreRequestImpl,
+    "/v1/runs",
+    "POST",
+    {
+      context_capsule_id: capsuleId,
+      analysis_profile_id: profileId,
+      analysis_profile_version: profileVersion,
+      purpose: requiredText(values.purpose, "Purpose"),
+      mode: "MOCK",
+      mock_fixture_id: "documented-observation",
+    },
+    idempotencyKey,
+  );
+}
+
+export function publicOperatorError(error) {
+  if (error instanceof OperatorValidationError) {
+    return { status: error.status, error: { code: error.code, message: error.message } };
+  }
+  if (error instanceof CoreApiError) {
+    const status = error.status >= 400 && error.status < 500 ? error.status : 502;
+    return {
+      status,
+      error: {
+        code: error.code,
+        message: status === 502 ? "The Core service is temporarily unavailable." : error.message,
+      },
+    };
+  }
+  return {
+    status: 500,
+    error: { code: "OPERATOR_REQUEST_FAILED", message: "The operator request could not be completed." },
+  };
+}

--- a/apps/web/tests/core-client.test.mjs
+++ b/apps/web/tests/core-client.test.mjs
@@ -28,6 +28,27 @@ test("WEB_BFF rejects credentials embedded in Core URL", () => {
   );
 });
 
+test("WEB_BFF exposes only safe idempotency response metadata", async () => {
+  const result = await coreRequest("/v1/projects/prj_test", {
+    method: "PUT",
+    body: { name: "Synthetic project" },
+    idempotencyKey: "web-create-project-request-1",
+    includeResponseMetadata: true,
+    environment: { CORE_API_BASE_URL: "https://core.internal" },
+    fetchImpl: async (_url, options) => {
+      assert.equal(options.headers["Idempotency-Key"], "web-create-project-request-1");
+      return new Response(JSON.stringify({ project_id: "prj_test" }), {
+        status: 200,
+        headers: { "Idempotency-Replayed": "true" },
+      });
+    },
+  });
+  assert.deepEqual(result, {
+    data: { project_id: "prj_test" },
+    idempotencyReplayed: true,
+  });
+});
+
 test("WEB_BFF source contains no direct persistence or public Core variable", () => {
   const sourceRoot = path.resolve(import.meta.dirname, "../src");
   const files = [];

--- a/apps/web/tests/operator-workflow.test.mjs
+++ b/apps/web/tests/operator-workflow.test.mjs
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+import { CoreApiError } from "../src/server/core-client.mjs";
+import {
+  loadOperatorWorkflow,
+  performOperatorAction,
+  publicOperatorError,
+  workflowIdempotencyKey,
+} from "../src/server/operator-workflow.mjs";
+
+test("operator snapshot uses filtered Core read APIs through the server", async () => {
+  const calls = [];
+  const responses = new Map([
+    ["/v1/projects?limit=100", [{ project_id: "prj_one", name: "One" }]],
+    ["/v1/analysis-profiles?limit=100", [{ analysis_profile_id: "AP-101", version: "1.0.0" }]],
+    ["/v1/projects/prj_one/corpora?limit=100", [{ corpus_id: "cor_one", name: "Corpus" }]],
+    ["/v1/contexts?project_id=prj_one&corpus_id=cor_one&limit=100", [{ context_id: "ctx_one" }]],
+    ["/v1/context-capsules?context_id=ctx_one&limit=100", [{ context_capsule_id: "cap_one" }]],
+    ["/v1/context-capsules/cap_one", { context_capsule_id: "cap_one", payload: {} }],
+  ]);
+  const snapshot = await loadOperatorWorkflow(
+    { projectId: "prj_one", corpusId: "cor_one", contextId: "ctx_one", capsuleId: "cap_one" },
+    { coreRequestImpl: async (requestPath) => { calls.push(requestPath); return responses.get(requestPath); } },
+  );
+  assert.equal(snapshot.projects[0].project_id, "prj_one");
+  assert.equal(snapshot.selectedCapsule.context_capsule_id, "cap_one");
+  assert.deepEqual(calls.sort(), [...responses.keys()].sort());
+});
+
+test("operator project creation generates the ID server-side and sends idempotency", async () => {
+  let captured;
+  const result = await performOperatorAction(
+    { action: "create_project", request_id: "request_12345678", values: { name: "Synthetic project" } },
+    {
+      uuidImpl: () => "00000000-0000-0000-0000-000000000001",
+      coreRequestImpl: async (requestPath, options) => {
+        captured = { requestPath, options };
+        return { data: { project_id: "prj_00000000000000000000000000000001" }, idempotencyReplayed: false };
+      },
+    },
+  );
+  assert.equal(captured.requestPath, "/v1/projects/prj_00000000000000000000000000000001");
+  assert.equal(captured.options.method, "PUT");
+  assert.equal(captured.options.idempotencyKey, "web-create_project-request_12345678");
+  assert.equal(captured.options.body.metadata.synthetic, true);
+  assert.equal(result.resource.project_id, "prj_00000000000000000000000000000001");
+});
+
+test("every intermediate Core write carries its stable idempotency key", async () => {
+  const cases = [
+    {
+      action: "create_corpus",
+      values: { project_id: "prj_one", name: "Synthetic corpus" },
+    },
+    {
+      action: "create_context",
+      values: { project_id: "prj_one", corpus_id: "cor_one", label: "Synthetic context" },
+    },
+    {
+      action: "create_capsule",
+      values: {
+        project_id: "prj_one",
+        corpus_id: "cor_one",
+        context_id: "ctx_one",
+        analysis_profile_id: "AP-101",
+        analysis_profile_version: "1.0.0",
+        purpose: "Synthetic capsule",
+      },
+    },
+  ];
+  for (const item of cases) {
+    let captured;
+    await performOperatorAction(
+      { ...item, request_id: "request_stable_123" },
+      {
+        uuidImpl: () => "00000000-0000-0000-0000-000000000002",
+        coreRequestImpl: async (requestPath, options) => {
+          captured = { requestPath, options };
+          return { data: {}, idempotencyReplayed: false };
+        },
+      },
+    );
+    assert.equal(captured.options.idempotencyKey, `web-${item.action}-request_stable_123`);
+    assert.equal(captured.options.includeResponseMetadata, true);
+  }
+});
+
+test("operator run remains MOCK-only and matches the immutable capsule profile", async () => {
+  const calls = [];
+  const result = await performOperatorAction(
+    {
+      action: "create_run",
+      request_id: "request_abcdefgh",
+      values: {
+        context_capsule_id: "cap_one",
+        analysis_profile_id: "AP-101",
+        analysis_profile_version: "1.0.0",
+        purpose: "Synthetic operator run",
+      },
+    },
+    {
+      coreRequestImpl: async (requestPath, options = {}) => {
+        calls.push({ requestPath, options });
+        if (options.method !== "POST") {
+          return {
+            context_capsule_id: "cap_one",
+            payload: { analysis_profile_id: "AP-101", analysis_profile_version: "1.0.0" },
+          };
+        }
+        return { data: { run_id: "run_one", status: "QUEUED" }, idempotencyReplayed: true };
+      },
+    },
+  );
+  assert.equal(calls[1].requestPath, "/v1/runs");
+  assert.equal(calls[1].options.body.mode, "MOCK");
+  assert.equal(calls[1].options.body.mock_fixture_id, "documented-observation");
+  assert.equal(calls[1].options.idempotencyKey, "web-create_run-request_abcdefgh");
+  assert.equal(result.idempotencyReplayed, true);
+});
+
+test("operator blocks profile changes against an immutable capsule", async () => {
+  await assert.rejects(
+    performOperatorAction(
+      {
+        action: "create_run",
+        request_id: "request_mismatch",
+        values: {
+          context_capsule_id: "cap_one",
+          analysis_profile_id: "AP-102",
+          analysis_profile_version: "2.0.0",
+          purpose: "Synthetic operator run",
+        },
+      },
+      {
+        coreRequestImpl: async () => ({
+          payload: { analysis_profile_id: "AP-101", analysis_profile_version: "1.0.0" },
+        }),
+      },
+    ),
+    (error) => error.code === "OPERATOR_CAPSULE_PROFILE_MISMATCH",
+  );
+});
+
+test("operator errors are sanitized before reaching the browser", () => {
+  const failure = publicOperatorError(
+    new CoreApiError(
+      "DATABASE_OPERATION_FAILED",
+      "postgresql://user:secret@database.internal/runtime",
+      503,
+      { password: "secret" },
+    ),
+  );
+  assert.equal(failure.status, 502);
+  assert.equal(failure.error.message, "The Core service is temporarily unavailable.");
+  assert.equal(JSON.stringify(failure).includes("secret"), false);
+});
+
+test("operator UI uses the Web BFF and does not expose manual resource ID inputs", () => {
+  const appRoot = path.resolve(import.meta.dirname, "../src/app");
+  const source = fs.readFileSync(path.join(appRoot, "workflow/workflow-client.js"), "utf8");
+  const styles = fs.readFileSync(path.join(appRoot, "styles.css"), "utf8");
+  assert.equal(source.includes('fetch("/api/operator/workflow"'), true);
+  assert.equal(source.includes('name="context_capsule_id"'), false);
+  assert.equal(source.includes("NEXT_PUBLIC_CORE"), false);
+  assert.equal(source.includes('mode: "LIVE"'), false);
+  assert.equal(source.includes('mode: "REPLAY"'), false);
+  assert.equal(source.includes("disabled={disabled"), true);
+  assert.equal(styles.includes("@media (max-width: 760px)"), true);
+});
+
+test("idempotency key derivation is stable and rejects malformed request IDs", () => {
+  assert.equal(
+    workflowIdempotencyKey("create_context", "request_same_123"),
+    workflowIdempotencyKey("create_context", "request_same_123"),
+  );
+  assert.throws(
+    () => workflowIdempotencyKey("create_context", "bad request"),
+    (error) => error.code === "OPERATOR_REQUEST_ID_INVALID",
+  );
+});


### PR DESCRIPTION
## Summary
- add the guided Project → Corpus → Context → ContextCapsule → AnalysisProfile → Run operator workflow
- route browser operations through the Web BFF with server-generated IDs and idempotent Core writes
- preserve MOCK-only execution, capsule immutability, sanitized errors, and responsive loading/empty/error states

## Validation
- `apps/web npm test` — 12 passed
- `apps/web npm run build` — PASS
- `git diff --check` — PASS

Closes #9