### PR TITLE
feat(web): add operator project-to-run workflow

### DIFF
--- a/apps/web/src/app/layout.js
+++ b/apps/web/src/app/layout.js
@@ -1,8 +1,8 @@
 import "./styles.css";
 
 export const metadata = {
-  title: "SOAIACORE P0",
-  description: "Synthetic-only SOAIACORE P0 runtime pilot",
+  title: "SOAIACORE Operator",
+  description: "Synthetic-only SOAIACORE internal operator workflow",
 };
 
 export default function RootLayout({ children }) {
@@ -10,7 +10,7 @@ export default function RootLayout({ children }) {
     <html lang="en">
       <body>
         <header>
-          <strong>SOAIACORE P0</strong>
+          <strong>SOAIACORE</strong>
           <span>MOCK · SYNTHETIC DATA ONLY</span>
         </header>
         <main>{children}</main>

--- a/apps/web/src/app/page.js
+++ b/apps/web/src/app/page.js
@@ -3,13 +3,14 @@ import Link from "next/link";
 export default function HomePage() {
   return (
     <section>
-      <p className="eyebrow">Architecture v0.6 · Provider mode MOCK</p>
-      <h1>Application runtime pilot</h1>
+      <p className="eyebrow">Architecture v0.6 · Internal operator · MOCK</p>
+      <h1>SOAIACORE operator workflow</h1>
       <p>
-        This interface submits synthetic runs through the server-side Web BFF. It never
-        connects to PostgreSQL, Blob Storage, or a model provider.
+        Prepare projects, corpora, contexts, immutable capsules, and synthetic runs through
+        the server-side Web BFF. The browser never connects directly to Core, PostgreSQL,
+        Blob Storage, or a model provider.
       </p>
-      <Link className="button" href="/runs/new">Create a synthetic run</Link>
+      <Link className="button" href="/runs/new">Prepare a synthetic run</Link>
     </section>
   );
 }

--- a/apps/web/src/app/runs/new/actions.js
+++ b/apps/web/src/app/runs/new/actions.js
@@ -1,25 +1,215 @@
 "use server";
 
-import { randomUUID } from "node:crypto";
 import { redirect } from "next/navigation";
 import { coreRequest } from "../../../server/core-client.mjs";
+import {
+  deterministicResourceId,
+  idempotencyKey,
+  profileFromCapsule,
+  publicErrorCode,
+  requiredIdentifier,
+  requiredProfileSelection,
+  requiredRequestToken,
+  requiredText,
+  syntheticContentHash,
+  workflowPath,
+} from "../../../server/operator-workflow.mjs";
 
-export async function createSyntheticRun(formData) {
-  const request = {
-    context_capsule_id: String(formData.get("context_capsule_id") ?? "").trim(),
-    analysis_profile_id: String(formData.get("analysis_profile_id") ?? "").trim(),
-    analysis_profile_version: String(
-      formData.get("analysis_profile_version") ?? "",
-    ).trim(),
-    purpose: String(formData.get("purpose") ?? "P0_SYNTHETIC_WEB").trim(),
-    mode: "MOCK",
-    mock_fixture_id: "documented-observation",
-  };
-  const result = await coreRequest("/v1/runs", {
-    method: "POST",
-    body: request,
-    idempotencyKey: `web-${randomUUID()}`,
-  });
-  redirect(`/runs/${encodeURIComponent(result.run_id)}`);
+function selection(formData) {
+  const values = {};
+  for (const key of ["project_id", "corpus_id", "context_id", "capsule_id"]) {
+    const value = String(formData.get(key) ?? "").trim();
+    if (value) values[key] = value;
+  }
+  return values;
 }
 
+function fail(error, values) {
+  redirect(workflowPath({ ...values, error: publicErrorCode(error) }));
+}
+
+export async function createProject(formData) {
+  const requestToken = String(formData.get("request_token") ?? "");
+  let projectId;
+  try {
+    requiredRequestToken(requestToken);
+    const name = requiredText(formData.get("name"), "project name");
+    projectId = deterministicResourceId("prj", requestToken);
+    await coreRequest(`/v1/projects/${encodeURIComponent(projectId)}`, {
+      method: "PUT",
+      body: { name, status: "ACTIVE", metadata: { synthetic: true, source: "WEB_OPERATOR" } },
+      idempotencyKey: idempotencyKey("project", requestToken),
+    });
+  } catch (error) {
+    fail(error, {});
+  }
+  redirect(workflowPath({ project_id: projectId, notice: "PROJECT_READY" }));
+}
+
+export async function createCorpus(formData) {
+  const values = selection(formData);
+  const requestToken = String(formData.get("request_token") ?? "");
+  let corpusId;
+  try {
+    const projectId = requiredIdentifier(values.project_id, "project ID");
+    requiredRequestToken(requestToken);
+    const name = requiredText(formData.get("name"), "corpus name");
+    corpusId = deterministicResourceId("cor", requestToken);
+    await coreRequest(
+      `/v1/projects/${encodeURIComponent(projectId)}/corpora/${encodeURIComponent(corpusId)}`,
+      {
+        method: "PUT",
+        body: { name, metadata: { synthetic: true, source: "WEB_OPERATOR" } },
+        idempotencyKey: idempotencyKey("corpus", requestToken),
+      },
+    );
+  } catch (error) {
+    fail(error, values);
+  }
+  redirect(workflowPath({ ...values, corpus_id: corpusId, notice: "CORPUS_READY" }));
+}
+
+export async function createContext(formData) {
+  const values = selection(formData);
+  const requestToken = String(formData.get("request_token") ?? "");
+  let contextId;
+  try {
+    const projectId = requiredIdentifier(values.project_id, "project ID");
+    const corpusId = requiredIdentifier(values.corpus_id, "corpus ID");
+    requiredRequestToken(requestToken);
+    const label = requiredText(formData.get("label"), "context label");
+    contextId = deterministicResourceId("ctx", requestToken);
+    await coreRequest("/v1/contexts", {
+      method: "POST",
+      body: {
+        context_id: contextId,
+        project_id: projectId,
+        context_type: "P1_SYNTHETIC",
+        dimensions: { corpus_id: corpusId, label, synthetic: true },
+      },
+      idempotencyKey: idempotencyKey("context", requestToken),
+    });
+  } catch (error) {
+    fail(error, values);
+  }
+  redirect(workflowPath({ ...values, context_id: contextId, notice: "CONTEXT_READY" }));
+}
+
+export async function createCapsule(formData) {
+  const values = selection(formData);
+  const requestToken = String(formData.get("request_token") ?? "");
+  let capsuleId;
+  try {
+    const projectId = requiredIdentifier(values.project_id, "project ID");
+    const corpusId = requiredIdentifier(values.corpus_id, "corpus ID");
+    const contextId = requiredIdentifier(values.context_id, "context ID");
+    const {
+      analysis_profile_id: profileId,
+      analysis_profile_version: profileVersion,
+    } = requiredProfileSelection(formData.get("analysis_profile"));
+    const label = requiredText(formData.get("label"), "capsule label");
+    requiredRequestToken(requestToken);
+
+    capsuleId = deterministicResourceId("cap", requestToken);
+    const subjectId = deterministicResourceId("sub", requestToken);
+    const evidenceRefId = deterministicResourceId("evref", requestToken);
+    const evidenceId = deterministicResourceId("ev", requestToken);
+    const sourceId = deterministicResourceId("src", requestToken);
+
+    await coreRequest("/v1/identity/resolve", {
+      method: "POST",
+      body: {
+        observed_actor_id: deterministicResourceId("act", requestToken),
+        corpus_id: corpusId,
+        source_local_ref: `fixture://actor/${subjectId}`,
+        display_label: "Synthetic operator subject",
+        canonical_subject_id: subjectId,
+        identity_resolution_status: "ADJUDICATED",
+        identity_claim_id: deterministicResourceId("idc", requestToken),
+        identity_decision_id: deterministicResourceId("idd", requestToken),
+        decision_type: "LINK",
+        evidence_refs: [evidenceRefId],
+      },
+      idempotencyKey: idempotencyKey("capsule-identity", requestToken),
+    });
+
+    await coreRequest("/v1/evidence/register", {
+      method: "POST",
+      body: {
+        source_id: sourceId,
+        corpus_id: corpusId,
+        source_type: "TEXT",
+        source_locator: `fixture://source/${sourceId}`,
+        content_sha256: syntheticContentHash(requestToken),
+        byte_size: 0,
+        source_metadata: { synthetic: true, source: "WEB_OPERATOR" },
+        evidence_id: evidenceId,
+        evidence_state: "ADMISSIBLE",
+        object_locator: `fixture://object/${evidenceId}`,
+        modality: "TEXT",
+        evidence_metadata: { synthetic: true },
+        evidence_ref_id: evidenceRefId,
+        locator: "bytes:0-0",
+        support_type: "DIRECT",
+        relationship: "SUPPORTS",
+        admissibility_scope: profileId,
+      },
+      idempotencyKey: idempotencyKey("capsule-evidence", requestToken),
+    });
+
+    await coreRequest("/v1/context-capsules", {
+      method: "POST",
+      body: {
+        context_capsule_id: capsuleId,
+        context_id: contextId,
+        schema_version: "P0-RUNTIME-1",
+        payload: {
+          project_id: projectId,
+          corpus_id: corpusId,
+          context_id: contextId,
+          analysis_profile_id: profileId,
+          analysis_profile_version: profileVersion,
+          identity_refs: [subjectId],
+          evidence_refs: [evidenceRefId],
+          synthetic_only: true,
+          purpose: "P1_INTERNAL_OPERATOR",
+          label,
+        },
+      },
+      idempotencyKey: idempotencyKey("capsule", requestToken),
+    });
+  } catch (error) {
+    fail(error, values);
+  }
+  redirect(workflowPath({ ...values, capsule_id: capsuleId, notice: "CAPSULE_READY" }));
+}
+
+export async function createSyntheticRun(formData) {
+  const values = selection(formData);
+  const requestToken = String(formData.get("request_token") ?? "");
+  let result;
+  try {
+    const capsuleId = requiredIdentifier(values.capsule_id, "capsule ID");
+    requiredRequestToken(requestToken);
+    const purpose = requiredText(formData.get("purpose"), "purpose");
+    const capsule = await coreRequest(
+      `/v1/context-capsules/${encodeURIComponent(capsuleId)}`,
+    );
+    const profile = profileFromCapsule(capsule);
+    if (!profile) throw new Error("CAPSULE_PROFILE_UNAVAILABLE");
+    result = await coreRequest("/v1/runs", {
+      method: "POST",
+      body: {
+        context_capsule_id: capsuleId,
+        ...profile,
+        purpose,
+        mode: "MOCK",
+        mock_fixture_id: "documented-observation",
+      },
+      idempotencyKey: idempotencyKey("run", requestToken),
+    });
+  } catch (error) {
+    fail(error, values);
+  }
+  redirect(`/runs/${encodeURIComponent(result.run_id)}`);
+}

--- a/apps/web/src/app/runs/new/error.js
+++ b/apps/web/src/app/runs/new/error.js
@@ -1,0 +1,14 @@
+"use client";
+
+export default function NewRunError({ reset }) {
+  return (
+    <section>
+      <p className="eyebrow">Internal operator</p>
+      <h1>Workflow unavailable</h1>
+      <p className="error" role="alert">
+        The workflow could not load safely. No credentials or internal response details were exposed.
+      </p>
+      <button onClick={() => reset()}>Try again</button>
+    </section>
+  );
+}

--- a/apps/web/src/app/runs/new/loading.js
+++ b/apps/web/src/app/runs/new/loading.js
@@ -1,0 +1,3 @@
+export default function LoadingNewRun() {
+  return <p className="notice" role="status">Loading operator workflow…</p>;
+}

--- a/apps/web/src/app/runs/new/page.js
+++ b/apps/web/src/app/runs/new/page.js
@@ -1,30 +1,286 @@
-import { createSyntheticRun } from "./actions";
+import { randomUUID } from "node:crypto";
+import { coreRequest } from "../../../server/core-client.mjs";
+import { profileFromCapsule, workflowPath } from "../../../server/operator-workflow.mjs";
+import {
+  createCapsule,
+  createContext,
+  createCorpus,
+  createProject,
+  createSyntheticRun,
+} from "./actions";
+import { SubmitButton } from "./submit-button";
 
-export default function NewRunPage() {
+export const dynamic = "force-dynamic";
+
+const notices = {
+  PROJECT_READY: "Project ready. Continue with a corpus.",
+  CORPUS_READY: "Corpus ready. Continue with a context.",
+  CONTEXT_READY: "Context ready. Create or select an immutable capsule.",
+  CAPSULE_READY: "Capsule snapshot ready. You can now queue a MOCK run.",
+};
+
+const errors = {
+  INVALID_PROJECT_NAME: "Enter a valid project name.",
+  INVALID_CORPUS_NAME: "Enter a valid corpus name.",
+  INVALID_CONTEXT_LABEL: "Enter a valid context label.",
+  INVALID_CAPSULE_LABEL: "Enter a valid capsule label.",
+  INVALID_REQUEST_TOKEN: "The form expired. Reload and try again.",
+  CAPSULE_PROFILE_UNAVAILABLE: "The selected capsule has no usable analysis profile.",
+  CORE_API_NOT_CONFIGURED: "Core is not configured for this Web environment.",
+  CORE_REQUEST_FAILED: "Core could not complete the request.",
+  REQUEST_FAILED: "The request could not be completed safely.",
+};
+
+function one(value) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function selected(items, field, requested) {
+  return items.find((item) => item[field] === requested) ?? null;
+}
+
+function TechnicalId({ value }) {
+  return <small className="technical">ID: {value}</small>;
+}
+
+function SelectionForm({ name, items, valueField, label, selectedValue, hidden = {} }) {
   return (
-    <section>
-      <p className="eyebrow">Synthetic input only</p>
-      <h1>Create run</h1>
-      <form action={createSyntheticRun}>
-        <label>
-          Context Capsule ID
-          <input name="context_capsule_id" required pattern="cap_[A-Za-z0-9_-]+" />
-        </label>
-        <label>
-          Analysis Profile ID
-          <input name="analysis_profile_id" required pattern="AP-[0-9]{3}" />
-        </label>
-        <label>
-          Analysis Profile version
-          <input name="analysis_profile_version" required />
-        </label>
-        <label>
-          Purpose
-          <input name="purpose" defaultValue="P0_SYNTHETIC_WEB" required />
-        </label>
-        <button type="submit">Queue MOCK run</button>
-      </form>
-    </section>
+    <form className="compact-form" method="get">
+      {Object.entries(hidden).map(([key, value]) => (
+        <input key={key} type="hidden" name={key} value={value} />
+      ))}
+      <label>
+        {label}
+        <select name={name} defaultValue={selectedValue ?? ""} required>
+          <option value="" disabled>Select an existing resource</option>
+          {items.map((item) => (
+            <option key={item[valueField]} value={item[valueField]}>
+              {item.name ?? item.dimensions?.label ?? item.context_type ?? "Immutable snapshot"} — {item[valueField]}
+            </option>
+          ))}
+        </select>
+      </label>
+      <SubmitButton pendingLabel="Selecting…">Use selection</SubmitButton>
+    </form>
   );
 }
 
+function HiddenSelection({ values }) {
+  return Object.entries(values).map(([name, value]) => (
+    <input key={name} type="hidden" name={name} value={value} />
+  ));
+}
+
+export default async function NewRunPage({ searchParams }) {
+  const query = await searchParams;
+  const requested = {
+    project_id: one(query?.project_id),
+    corpus_id: one(query?.corpus_id),
+    context_id: one(query?.context_id),
+    capsule_id: one(query?.capsule_id),
+  };
+
+  const [projects, profiles] = await Promise.all([
+    coreRequest("/v1/projects?limit=100"),
+    coreRequest("/v1/analysis-profiles?limit=100"),
+  ]);
+  const project = selected(projects, "project_id", requested.project_id);
+  const corpora = project
+    ? await coreRequest(`/v1/projects/${encodeURIComponent(project.project_id)}/corpora?limit=100`)
+    : [];
+  const corpus = selected(corpora, "corpus_id", requested.corpus_id);
+  const contexts = corpus
+    ? await coreRequest(
+        `/v1/contexts?${new URLSearchParams({
+          project_id: project.project_id,
+          corpus_id: corpus.corpus_id,
+          limit: "100",
+        })}`,
+      )
+    : [];
+  const context = selected(contexts, "context_id", requested.context_id);
+  const capsules = context
+    ? await coreRequest(
+        `/v1/context-capsules?${new URLSearchParams({
+          context_id: context.context_id,
+          limit: "100",
+        })}`,
+      )
+    : [];
+  const capsule = selected(capsules, "context_capsule_id", requested.capsule_id);
+  const capsuleDetail = capsule
+    ? await coreRequest(`/v1/context-capsules/${encodeURIComponent(capsule.context_capsule_id)}`)
+    : null;
+  const capsuleProfile = profileFromCapsule(capsuleDetail);
+  const activeSelection = {
+    ...(project && { project_id: project.project_id }),
+    ...(corpus && { corpus_id: corpus.corpus_id }),
+    ...(context && { context_id: context.context_id }),
+    ...(capsule && { capsule_id: capsule.context_capsule_id }),
+  };
+  const notice = notices[one(query?.notice)];
+  const errorCode = one(query?.error);
+  const error = errors[errorCode] ?? (errorCode ? errors.REQUEST_FAILED : null);
+
+  return (
+    <section>
+      <p className="eyebrow">Internal operator · MOCK only · synthetic data</p>
+      <h1>Prepare a run</h1>
+      <p className="lede">
+        Select existing resources or create synthetic ones. Technical identifiers remain
+        visible for traceability, but you never need to copy or type them.
+      </p>
+
+      {notice && <p className="notice" role="status">{notice}</p>}
+      {error && <p className="error" role="alert">{error}</p>}
+
+      <ol className="workflow">
+        <li className={project ? "complete" : "active"}>
+          <div className="step-heading"><span>1</span><h2>Project</h2></div>
+          {projects.length ? (
+            <SelectionForm
+              name="project_id"
+              items={projects}
+              valueField="project_id"
+              label="Existing project"
+              selectedValue={project?.project_id}
+            />
+          ) : <p className="empty">No projects yet. Create the first synthetic project.</p>}
+          <details open={!projects.length}>
+            <summary>Create project</summary>
+            <form action={createProject}>
+              <input type="hidden" name="request_token" value={randomUUID()} />
+              <label>Project name<input name="name" maxLength={200} required /></label>
+              <SubmitButton pendingLabel="Creating project…">Create project</SubmitButton>
+            </form>
+          </details>
+          {project && <p className="selection">Selected: <strong>{project.name}</strong><TechnicalId value={project.project_id} /></p>}
+        </li>
+
+        <li className={corpus ? "complete" : project ? "active" : "locked"}>
+          <div className="step-heading"><span>2</span><h2>Corpus</h2></div>
+          {!project ? <p className="empty">Select a project to continue.</p> : (
+            <>
+              {corpora.length ? (
+                <SelectionForm
+                  name="corpus_id"
+                  items={corpora}
+                  valueField="corpus_id"
+                  label="Existing corpus"
+                  selectedValue={corpus?.corpus_id}
+                  hidden={{ project_id: project.project_id }}
+                />
+              ) : <p className="empty">This project has no corpora yet.</p>}
+              <details open={!corpora.length}>
+                <summary>Create corpus</summary>
+                <form action={createCorpus}>
+                  <HiddenSelection values={{ project_id: project.project_id }} />
+                  <input type="hidden" name="request_token" value={randomUUID()} />
+                  <label>Corpus name<input name="name" maxLength={200} required /></label>
+                  <SubmitButton pendingLabel="Creating corpus…">Create corpus</SubmitButton>
+                </form>
+              </details>
+            </>
+          )}
+          {corpus && <p className="selection">Selected: <strong>{corpus.name}</strong><TechnicalId value={corpus.corpus_id} /></p>}
+        </li>
+
+        <li className={context ? "complete" : corpus ? "active" : "locked"}>
+          <div className="step-heading"><span>3</span><h2>Context</h2></div>
+          {!corpus ? <p className="empty">Select a corpus to continue.</p> : (
+            <>
+              {contexts.length ? (
+                <SelectionForm
+                  name="context_id"
+                  items={contexts}
+                  valueField="context_id"
+                  label="Existing context"
+                  selectedValue={context?.context_id}
+                  hidden={{ project_id: project.project_id, corpus_id: corpus.corpus_id }}
+                />
+              ) : <p className="empty">This corpus has no contexts yet.</p>}
+              <details open={!contexts.length}>
+                <summary>Create context</summary>
+                <form action={createContext}>
+                  <HiddenSelection values={{ project_id: project.project_id, corpus_id: corpus.corpus_id }} />
+                  <input type="hidden" name="request_token" value={randomUUID()} />
+                  <label>Context label<input name="label" maxLength={200} required /></label>
+                  <SubmitButton pendingLabel="Creating context…">Create context</SubmitButton>
+                </form>
+              </details>
+            </>
+          )}
+          {context && <p className="selection">Selected: <strong>{context.dimensions?.label ?? context.context_type}</strong><TechnicalId value={context.context_id} /></p>}
+        </li>
+
+        <li className={capsule ? "complete" : context ? "active" : "locked"}>
+          <div className="step-heading"><span>4</span><h2>Context capsule</h2></div>
+          {!context ? <p className="empty">Select a context to continue.</p> : (
+            <>
+              {capsules.length ? (
+                <SelectionForm
+                  name="capsule_id"
+                  items={capsules}
+                  valueField="context_capsule_id"
+                  label="Existing immutable snapshot"
+                  selectedValue={capsule?.context_capsule_id}
+                  hidden={{
+                    project_id: project.project_id,
+                    corpus_id: corpus.corpus_id,
+                    context_id: context.context_id,
+                  }}
+                />
+              ) : <p className="empty">This context has no capsule snapshots yet.</p>}
+              <details open={!capsules.length}>
+                <summary>Create immutable capsule</summary>
+                {profiles.length ? (
+                  <form action={createCapsule}>
+                    <HiddenSelection values={{
+                      project_id: project.project_id,
+                      corpus_id: corpus.corpus_id,
+                      context_id: context.context_id,
+                    }} />
+                    <input type="hidden" name="request_token" value={randomUUID()} />
+                    <label>Snapshot label<input name="label" maxLength={200} required /></label>
+                    <label>
+                      Analysis profile
+                      <select name="analysis_profile" required>
+                        {profiles.map((profile) => (
+                          <option
+                            key={`${profile.analysis_profile_id}:${profile.version}`}
+                            value={`${profile.analysis_profile_id}@${profile.version}`}
+                          >
+                            {profile.name ?? "Analysis profile"} — {profile.analysis_profile_id} v{profile.version}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                    <p className="hint">Creates synthetic identity and evidence references required by the runtime. The snapshot is immutable.</p>
+                    <SubmitButton pendingLabel="Creating capsule…">Create capsule</SubmitButton>
+                  </form>
+                ) : <p className="error">No analysis profiles are available. Seed one through the approved Core workflow.</p>}
+              </details>
+            </>
+          )}
+          {capsule && <p className="selection">Selected immutable snapshot<TechnicalId value={capsule.context_capsule_id} /></p>}
+        </li>
+
+        <li className={capsule ? "active" : "locked"}>
+          <div className="step-heading"><span>5</span><h2>Queue run</h2></div>
+          {!capsule ? <p className="empty">Select a capsule to continue.</p> : capsuleProfile ? (
+            <form action={createSyntheticRun}>
+              <HiddenSelection values={activeSelection} />
+              <input type="hidden" name="request_token" value={randomUUID()} />
+              <p className="selection">
+                Profile: <strong>{capsuleProfile.analysis_profile_id} v{capsuleProfile.analysis_profile_version}</strong>
+              </p>
+              <label>Purpose<input name="purpose" defaultValue="P1_INTERNAL_OPERATOR" maxLength={200} required /></label>
+              <SubmitButton pendingLabel="Queueing run…">Queue MOCK run</SubmitButton>
+            </form>
+          ) : <p className="error">This capsule cannot be queued because its profile metadata is unavailable.</p>}
+        </li>
+      </ol>
+      <p className="reset"><a href={workflowPath()}>Start over</a></p>
+    </section>
+  );
+}

--- a/apps/web/src/app/runs/new/submit-button.js
+++ b/apps/web/src/app/runs/new/submit-button.js
@@ -1,0 +1,12 @@
+"use client";
+
+import { useFormStatus } from "react-dom";
+
+export function SubmitButton({ children, pendingLabel = "Working…" }) {
+  const { pending } = useFormStatus();
+  return (
+    <button type="submit" disabled={pending} aria-disabled={pending}>
+      {pending ? pendingLabel : children}
+    </button>
+  );
+}

--- a/apps/web/src/app/styles.css
+++ b/apps/web/src/app/styles.css
@@ -15,19 +15,21 @@ header {
   padding: 1rem 2rem;
 }
 header span, .eyebrow { color: #75d7ff; font-size: .78rem; letter-spacing: .12em; }
-main { margin: 0 auto; max-width: 760px; padding: 4rem 1.5rem; }
+main { margin: 0 auto; max-width: 900px; padding: 4rem 1.5rem; }
 h1 { font-size: clamp(2rem, 7vw, 4.5rem); line-height: 1; }
 h2 { margin-top: 2rem; }
 p { color: #b7c4d8; line-height: 1.7; }
 form { display: grid; gap: 1rem; }
 label { display: grid; gap: .45rem; }
-input {
+input, select {
   background: #101d30;
   border: 1px solid #334968;
   border-radius: .5rem;
   color: inherit;
+  min-width: 0;
   padding: .8rem;
 }
+button:disabled { cursor: progress; opacity: .65; }
 .button, button {
   background: #52c7f5;
   border: 0;
@@ -43,4 +45,55 @@ dl { display: grid; grid-template-columns: 10rem 1fr; gap: .6rem; }
 dt { color: #8fa3bf; }
 dd { margin: 0; }
 pre { background: #101d30; border-radius: .5rem; overflow: auto; padding: 1rem; }
+.lede { max-width: 68ch; }
+.notice, .error {
+  border: 1px solid #2f5870;
+  border-radius: .65rem;
+  padding: .8rem 1rem;
+}
+.notice { background: #0d2634; color: #aee8ff; }
+.error { background: #351a24; border-color: #814159; color: #ffd6e1; }
+.workflow { display: grid; gap: 1rem; list-style: none; margin: 2rem 0; padding: 0; }
+.workflow > li {
+  background: #0c1727;
+  border: 1px solid #263a55;
+  border-radius: .85rem;
+  padding: 1.25rem;
+}
+.workflow > li.active { border-color: #52c7f5; }
+.workflow > li.complete { border-color: #2c7c68; }
+.workflow > li.locked { opacity: .68; }
+.step-heading { align-items: center; display: flex; gap: .75rem; }
+.step-heading span {
+  align-items: center;
+  background: #1d3550;
+  border-radius: 999px;
+  color: #9be4ff;
+  display: inline-flex;
+  font-weight: 800;
+  height: 2rem;
+  justify-content: center;
+  width: 2rem;
+}
+.step-heading h2 { margin: 0; }
+.compact-form { grid-template-columns: minmax(0, 1fr) auto; margin-top: 1rem; }
+.compact-form label { grid-column: 1; }
+.compact-form button { align-self: end; grid-column: 2; }
+details { border-top: 1px solid #24334a; margin-top: 1rem; padding-top: 1rem; }
+summary { color: #75d7ff; cursor: pointer; font-weight: 700; margin-bottom: 1rem; }
+.selection { align-items: baseline; display: flex; flex-wrap: wrap; gap: .5rem; }
+.technical { color: #7f93ad; font-family: ui-monospace, monospace; }
+.empty, .hint { color: #8fa3bf; }
+.hint { font-size: .9rem; }
+.reset { text-align: right; }
+.reset a { color: #75d7ff; }
+
+@media (max-width: 640px) {
+  header { align-items: flex-start; flex-direction: column; gap: .35rem; padding: 1rem; }
+  main { padding: 2.5rem 1rem; }
+  .compact-form { grid-template-columns: 1fr; }
+  .compact-form button { grid-column: 1; }
+  dl { grid-template-columns: 1fr; }
+  dd { margin-bottom: .5rem; }
+}
 

--- a/apps/web/src/server/operator-workflow.mjs
+++ b/apps/web/src/server/operator-workflow.mjs
@@ -1,0 +1,91 @@
+import { createHash } from "node:crypto";
+
+const IDENTIFIER = /^[A-Za-z0-9_.:-]{1,200}$/;
+const PROFILE_ID = /^AP-[0-9]{3}$/;
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function requiredText(value, label, maxLength = 200) {
+  const text = String(value ?? "").trim();
+  if (!text || text.length > maxLength) {
+    throw new Error(`INVALID_${label.toUpperCase().replaceAll(" ", "_")}`);
+  }
+  return text;
+}
+
+export function requiredIdentifier(value, label = "identifier") {
+  const identifier = requiredText(value, label);
+  if (!IDENTIFIER.test(identifier)) {
+    throw new Error(`INVALID_${label.toUpperCase().replaceAll(" ", "_")}`);
+  }
+  return identifier;
+}
+
+export function requiredProfileId(value) {
+  const profileId = requiredText(value, "analysis profile ID");
+  if (!PROFILE_ID.test(profileId)) throw new Error("INVALID_ANALYSIS_PROFILE_ID");
+  return profileId;
+}
+
+export function requiredProfileSelection(value) {
+  const selection = requiredText(value, "analysis profile", 300);
+  const separator = selection.indexOf("@");
+  if (separator < 1) throw new Error("INVALID_ANALYSIS_PROFILE");
+  return {
+    analysis_profile_id: requiredProfileId(selection.slice(0, separator)),
+    analysis_profile_version: requiredText(
+      selection.slice(separator + 1),
+      "analysis profile version",
+    ),
+  };
+}
+
+export function requiredRequestToken(value) {
+  const token = String(value ?? "").trim();
+  if (!UUID.test(token)) throw new Error("INVALID_REQUEST_TOKEN");
+  return token.toLowerCase();
+}
+
+export function deterministicResourceId(prefix, requestToken) {
+  const token = requiredRequestToken(requestToken).replaceAll("-", "");
+  return `${prefix}_${token}`;
+}
+
+export function idempotencyKey(operation, requestToken) {
+  return `web-${operation}-${requiredRequestToken(requestToken)}`;
+}
+
+export function syntheticContentHash(requestToken) {
+  return createHash("sha256")
+    .update(`SOAIACORE synthetic operator fixture ${requiredRequestToken(requestToken)}`)
+    .digest("hex");
+}
+
+export function workflowPath(values = {}) {
+  const query = new URLSearchParams();
+  for (const key of ["project_id", "corpus_id", "context_id", "capsule_id", "notice", "error"]) {
+    if (values[key]) query.set(key, String(values[key]));
+  }
+  const suffix = query.toString();
+  return suffix ? `/runs/new?${suffix}` : "/runs/new";
+}
+
+export function publicErrorCode(error) {
+  const code = String(error?.code ?? error?.message ?? "REQUEST_FAILED");
+  return /^[A-Z0-9_]{1,80}$/.test(code) ? code : "REQUEST_FAILED";
+}
+
+export function profileFromCapsule(capsule) {
+  const payload = capsule?.payload;
+  if (!payload || typeof payload !== "object") return null;
+  try {
+    return {
+      analysis_profile_id: requiredProfileId(payload.analysis_profile_id),
+      analysis_profile_version: requiredText(
+        payload.analysis_profile_version,
+        "analysis profile version",
+      ),
+    };
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/tests/core-client.test.mjs
+++ b/apps/web/tests/core-client.test.mjs
@@ -3,6 +3,15 @@ import fs from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import { CoreApiError, coreBaseUrl, coreRequest } from "../src/server/core-client.mjs";
+import {
+  deterministicResourceId,
+  idempotencyKey,
+  profileFromCapsule,
+  publicErrorCode,
+  requiredProfileSelection,
+  requiredRequestToken,
+  workflowPath,
+} from "../src/server/operator-workflow.mjs";
 
 test("WEB_BFF uses CORE_API_BASE_URL only on the server request", async () => {
   let captured;
@@ -44,4 +53,38 @@ test("WEB_BFF source contains no direct persistence or public Core variable", ()
   assert.equal(source.includes("DATABASE_URL"), false);
   assert.equal(source.includes("POSTGRES_PASSWORD"), false);
   assert.equal(source.includes("AZURE_STORAGE_CONNECTION_STRING"), false);
+});
+
+test("operator workflow derives replay-safe resource and idempotency identifiers", () => {
+  const token = "123e4567-e89b-42d3-a456-426614174000";
+  assert.equal(
+    deterministicResourceId("prj", token),
+    "prj_123e4567e89b42d3a456426614174000",
+  );
+  assert.equal(idempotencyKey("project", token), `web-project-${token}`);
+  assert.equal(requiredRequestToken(token.toUpperCase()), token);
+  assert.throws(() => requiredRequestToken("not-a-token"), /INVALID_REQUEST_TOKEN/);
+});
+
+test("operator workflow keeps selections in Web URLs and sanitizes error codes", () => {
+  assert.equal(
+    workflowPath({ project_id: "prj one", corpus_id: "cor/one", notice: "READY" }),
+    "/runs/new?project_id=prj+one&corpus_id=cor%2Fone&notice=READY",
+  );
+  assert.equal(publicErrorCode({ code: "RESOURCE_NOT_FOUND" }), "RESOURCE_NOT_FOUND");
+  assert.equal(publicErrorCode({ message: "unsafe error detail" }), "REQUEST_FAILED");
+});
+
+test("operator workflow resolves the profile from an immutable capsule", () => {
+  assert.deepEqual(requiredProfileSelection("AP-101@1.0.0"), {
+    analysis_profile_id: "AP-101",
+    analysis_profile_version: "1.0.0",
+  });
+  assert.deepEqual(
+    profileFromCapsule({
+      payload: { analysis_profile_id: "AP-101", analysis_profile_version: "1.0.0" },
+    }),
+    { analysis_profile_id: "AP-101", analysis_profile_version: "1.0.0" },
+  );
+  assert.equal(profileFromCapsule({ payload: { analysis_profile_id: "bad" } }), null);
 });

--- a/receipts/ISSUE_9_VALIDATION_2026-08-26.md
+++ b/receipts/ISSUE_9_VALIDATION_2026-08-26.md
@@ -1,0 +1,41 @@
+# Issue #9 — Web operator workflow validation
+
+Date: 2026-08-26  
+Branch: `feat/p1-02-web-workflow`  
+Base: `f426bc821f5eadedfcf11d0c0f8ba1d832d0bba5`
+
+## Outcome
+
+`P1_02_WEB_OPERATOR_WORKFLOW=IMPLEMENTED`
+
+The Web BFF now supports a progressive Project → Corpus → Context → immutable
+ContextCapsule → MOCK Run workflow. The browser only submits Web forms and never
+receives Core, database, Blob, or provider credentials.
+
+## Validation
+
+| Gate | Result |
+| --- | --- |
+| `apps/web`: `npm test` | PASS — 6/6 |
+| `apps/web`: `npm run build` | PASS — Next.js 16.3.2 |
+| `git diff --check` | PASS |
+| Existing PostgreSQL/runtime gates | Not rerun; previously PASS for Issue #8 |
+
+## Guardrails verified
+
+- All Core mutations use stable, operation-scoped idempotency keys.
+- Resource identifiers are derived from a validated request token for replay safety.
+- Capsule creation seeds only synthetic identity/evidence metadata required by the runtime.
+- ContextCapsule profile/version are selected as one coupled value and recovered from the immutable capsule when queueing a run.
+- MOCK is the only run mode exposed.
+- Loading, empty, pending, validation, and sanitized error states are present.
+- No architecture, Azure, Terraform, GHCR, or Core schema changes were made.
+
+## Delivery state
+
+`COMMIT=NOT_CREATED`
+
+`PUSH=NOT_PERFORMED`
+
+`READY_FOR_REVIEW=YES`
+

--- a/receipts/ISSUE_9_VALIDATION_2026-08-26.md
+++ b/receipts/ISSUE_9_VALIDATION_2026-08-26.md
@@ -33,9 +33,10 @@ receives Core, database, Blob, or provider credentials.
 
 ## Delivery state
 
-`COMMIT=NOT_CREATED`
+`IMPLEMENTATION_COMMIT=0e18947`
 
-`PUSH=NOT_PERFORMED`
+`PUBLISHED_BRANCH=feat/p1-02-web-workflow-codex`
+
+`PULL_REQUEST=23`
 
 `READY_FOR_REVIEW=YES`
-


### PR DESCRIPTION
## Summary\n\n- Add the guided internal operator workflow for Project → Corpus → Context → immutable ContextCapsule → MOCK Run.\n- Keep all Core calls server-side through the Web BFF.\n- Add stable idempotency keys, synthetic identity/evidence metadata, responsive states, and sanitized errors.\n\n## Validation\n\n- apps/web: npm test — 6 passed\n- apps/web: npm run build — passed (Next.js 16.3.2)\n- git diff --check — passed\n- PostgreSQL/runtime gates were not rerun because Issue #8 already passed.\n\nCloses #9