### PR TITLE
feat(web): harden operator portal UX

### DIFF
--- a/apps/web/src/app/api/runs/[runId]/route.js
+++ b/apps/web/src/app/api/runs/[runId]/route.js
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { coreRequest } from "../../../../server/core-client.mjs";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(_request, { params }) {
+  const { runId } = await params;
+  try {
+    const run = await coreRequest(`/v1/runs/${encodeURIComponent(runId)}`);
+    return NextResponse.json(run, {
+      headers: { "Cache-Control": "no-store" },
+    });
+  } catch {
+    return NextResponse.json(
+      { error: { code: "RUN_STATUS_UNAVAILABLE", message: "Unable to load run status." } },
+      { status: 502, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+}

--- a/apps/web/src/app/layout.js
+++ b/apps/web/src/app/layout.js
@@ -10,9 +10,15 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <body>
-        <header>
-          <Link className="brand" href="/">SOAIACORE P0</Link>
-          <span>MOCK · SYNTHETIC DATA ONLY</span>
+        <header className="site-header">
+          <div className="header-inner">
+            <Link className="brand" href="/">SOAIACORE P0</Link>
+            <nav aria-label="Primary navigation">
+              <Link href="/">Portal</Link>
+              <Link href="/workflow">Operator workflow</Link>
+            </nav>
+            <span className="environment-badge">MOCK · SYNTHETIC DATA ONLY</span>
+          </div>
         </header>
         <main>{children}</main>
       </body>

--- a/apps/web/src/app/page.js
+++ b/apps/web/src/app/page.js
@@ -2,14 +2,53 @@ import Link from "next/link";
 
 export default function HomePage() {
   return (
-    <section>
-      <p className="eyebrow">Architecture v0.6 · Provider mode MOCK</p>
-      <h1>Application runtime pilot</h1>
-      <p>
-        This interface submits synthetic runs through the server-side Web BFF. It never
-        connects to PostgreSQL, Blob Storage, or a model provider.
-      </p>
-      <Link className="button" href="/workflow">Open operator workflow</Link>
+    <section className="portal-home">
+      <div className="portal-hero">
+        <div>
+          <p className="eyebrow">Architecture v0.6 · Operator portal</p>
+          <h1>Run a bounded synthetic analysis.</h1>
+          <p className="hero-copy">
+            Prepare the approved context, validate the run, and inspect its receipt from one
+            guided workflow. Every action stays inside the server-side Web BFF.
+          </p>
+          <div className="hero-actions">
+            <Link className="button primary-action" href="/workflow">Open operator workflow</Link>
+            <Link className="text-link" href="/workflow#workflow-steps">See the three-stage flow</Link>
+          </div>
+        </div>
+        <aside className="portal-status-card" aria-label="Runtime status">
+          <p className="eyebrow">Runtime status</p>
+          <strong>READY · MOCK</strong>
+          <dl>
+            <dt>Data</dt><dd>Synthetic only</dd>
+            <dt>Provider</dt><dd>Server-side BFF</dd>
+            <dt>Cloud writes</dt><dd>Disabled</dd>
+          </dl>
+        </aside>
+      </div>
+
+      <div className="portal-grid" aria-label="Operator workflow overview">
+        <article className="portal-card">
+          <span className="card-number">01</span>
+          <h2>Prepare</h2>
+          <p>Select the project, corpus, context and immutable capsule for the run.</p>
+        </article>
+        <article className="portal-card">
+          <span className="card-number">02</span>
+          <h2>Validate</h2>
+          <p>Choose the approved analysis profile and confirm the pre-run guardrails.</p>
+        </article>
+        <article className="portal-card">
+          <span className="card-number">03</span>
+          <h2>Inspect</h2>
+          <p>Follow status updates and open the terminal ContextReceipt when ready.</p>
+        </article>
+      </div>
+
+      <div className="guardrail-banner" role="note">
+        <strong>Safe by design.</strong> This pilot does not connect to production data, Azure,
+        Blob Storage, or an external model provider.
+      </div>
     </section>
   );
 }

--- a/apps/web/src/app/receipts/[runId]/page.js
+++ b/apps/web/src/app/receipts/[runId]/page.js
@@ -1,4 +1,5 @@
 import { coreRequest } from "../../../server/core-client.mjs";
+import Link from "next/link";
 
 export const dynamic = "force-dynamic";
 
@@ -6,9 +7,10 @@ export default async function ReceiptPage({ params }) {
   const { runId } = await params;
   const receipt = await coreRequest(`/v1/runs/${encodeURIComponent(runId)}/receipt`);
   return (
-    <section>
+    <section className="receipt-page">
       <p className="eyebrow">ContextReceipt</p>
       <h1>{receipt.context_receipt_id}</h1>
+      <p className="page-intro">Immutable terminal evidence for this synthetic run.</p>
       <dl>
         <dt>Output</dt><dd>{receipt.output_status}</dd>
         <dt>Review policy</dt><dd>{receipt.review_mode ?? "NONE"}</dd>
@@ -18,7 +20,10 @@ export default async function ReceiptPage({ params }) {
       <pre>{JSON.stringify(receipt.claims_created, null, 2)}</pre>
       <h2>Limitations</h2>
       <pre>{JSON.stringify(receipt.limitations, null, 2)}</pre>
+      <div className="page-actions">
+        <Link className="button" href={`/runs/${encodeURIComponent(runId)}`}>Back to run status</Link>
+        <Link className="text-link" href="/workflow">Start another run</Link>
+      </div>
     </section>
   );
 }
-

--- a/apps/web/src/app/runs/[runId]/page.js
+++ b/apps/web/src/app/runs/[runId]/page.js
@@ -1,36 +1,10 @@
-import Link from "next/link";
 import { coreRequest } from "../../../server/core-client.mjs";
+import RunStatusClient from "./run-status-client";
 
 export const dynamic = "force-dynamic";
 
 export default async function RunPage({ params }) {
   const { runId } = await params;
   const run = await coreRequest(`/v1/runs/${encodeURIComponent(runId)}`);
-  const terminal = [
-    "COMPLETED",
-    "REVIEW_REQUIRED",
-    "DENIED",
-    "FAILED_PRECHECK",
-    "FAILED_EXECUTION",
-    "FAILED_VALIDATION",
-  ].includes(run.status);
-  return (
-    <section>
-      <p className="eyebrow">Run</p>
-      <h1>{run.run_id}</h1>
-      <dl>
-        <dt>Status</dt><dd>{run.status}</dd>
-        <dt>Job</dt><dd>{run.job_status ?? "UNAVAILABLE"}</dd>
-        <dt>Mode</dt><dd>{run.mode}</dd>
-      </dl>
-      {terminal ? (
-        <Link className="button" href={`/receipts/${encodeURIComponent(run.run_id)}`}>
-          View ContextReceipt
-        </Link>
-      ) : (
-        <p>The manually triggered Worker has not produced a terminal receipt yet.</p>
-      )}
-    </section>
-  );
+  return <RunStatusClient runId={runId} initialRun={run} />;
 }
-

--- a/apps/web/src/app/runs/[runId]/run-status-client.js
+++ b/apps/web/src/app/runs/[runId]/run-status-client.js
@@ -1,0 +1,83 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+
+const TERMINAL_STATUSES = new Set([
+  "COMPLETED",
+  "REVIEW_REQUIRED",
+  "DENIED",
+  "FAILED_PRECHECK",
+  "FAILED_EXECUTION",
+  "FAILED_VALIDATION",
+]);
+
+export default function RunStatusClient({ runId, initialRun }) {
+  const [run, setRun] = useState(initialRun);
+  const [refreshError, setRefreshError] = useState("");
+  const [refreshing, setRefreshing] = useState(false);
+  const terminal = useMemo(() => TERMINAL_STATUSES.has(run?.status), [run?.status]);
+
+  useEffect(() => {
+    if (terminal) return undefined;
+
+    let cancelled = false;
+    const refresh = async () => {
+      setRefreshing(true);
+      try {
+        const response = await fetch(`/api/runs/${encodeURIComponent(runId)}`, {
+          cache: "no-store",
+          headers: { Accept: "application/json" },
+        });
+        if (!response.ok) throw new Error("Unable to refresh run status.");
+        const nextRun = await response.json();
+        if (!cancelled) {
+          setRun(nextRun);
+          setRefreshError("");
+        }
+      } catch (error) {
+        if (!cancelled) setRefreshError(error.message);
+      } finally {
+        if (!cancelled) setRefreshing(false);
+      }
+    };
+
+    const interval = window.setInterval(refresh, 3000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [runId, terminal]);
+
+  const status = run?.status ?? "UNKNOWN";
+  const statusClass = `status-badge status-${status.toLowerCase().replaceAll("_", "-")}`;
+
+  return (
+    <section className="run-page">
+      <p className="eyebrow">Run status</p>
+      <div className="run-heading">
+        <div>
+          <h1>{run?.run_id ?? runId}</h1>
+          <p className="page-intro">The portal refreshes active runs automatically.</p>
+        </div>
+        <span className={statusClass} aria-live="polite">{status}</span>
+      </div>
+      <dl className="run-summary">
+        <dt>Job</dt><dd>{run?.job_status ?? "UNAVAILABLE"}</dd>
+        <dt>Mode</dt><dd>{run?.mode ?? "MOCK"}</dd>
+        <dt>Refresh</dt><dd>{terminal ? "Complete" : refreshing ? "Checking…" : "Every 3 seconds"}</dd>
+      </dl>
+      {refreshError ? <p className="notice error" role="status">{refreshError} We will retry automatically.</p> : null}
+      {terminal ? (
+        <div className="page-actions">
+          <Link className="button" href={`/receipts/${encodeURIComponent(run.run_id)}`}>
+            View ContextReceipt
+          </Link>
+          <Link className="text-link" href="/workflow">Start another run</Link>
+        </div>
+      ) : (
+        <p className="loading-panel" role="status">The worker is processing this run. Keep this page open to follow the transition.</p>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/app/runs/new/page.js
+++ b/apps/web/src/app/runs/new/page.js
@@ -1,30 +1,15 @@
-import { createSyntheticRun } from "./actions";
+import Link from "next/link";
 
 export default function NewRunPage() {
   return (
-    <section>
-      <p className="eyebrow">Synthetic input only</p>
-      <h1>Create run</h1>
-      <form action={createSyntheticRun}>
-        <label>
-          Context Capsule ID
-          <input name="context_capsule_id" required pattern="cap_[A-Za-z0-9_-]+" />
-        </label>
-        <label>
-          Analysis Profile ID
-          <input name="analysis_profile_id" required pattern="AP-[0-9]{3}" />
-        </label>
-        <label>
-          Analysis Profile version
-          <input name="analysis_profile_version" required />
-        </label>
-        <label>
-          Purpose
-          <input name="purpose" defaultValue="P0_SYNTHETIC_WEB" required />
-        </label>
-        <button type="submit">Queue MOCK run</button>
-      </form>
+    <section className="empty-state-page">
+      <p className="eyebrow">Operator workflow</p>
+      <h1>Runs start in the guided workflow.</h1>
+      <p>
+        Resource identifiers are selected and validated by the portal. You do not need to type
+        capsule or profile IDs manually.
+      </p>
+      <Link className="button" href="/workflow">Open operator workflow</Link>
     </section>
   );
 }
-

--- a/apps/web/src/app/styles.css
+++ b/apps/web/src/app/styles.css
@@ -7,15 +7,21 @@
 
 * { box-sizing: border-box; }
 body { margin: 0; min-height: 100vh; }
-header {
+.site-header { border-bottom: 1px solid #24334a; }
+.header-inner {
   align-items: center;
-  border-bottom: 1px solid #24334a;
   display: flex;
+  gap: 1.5rem;
   justify-content: space-between;
+  margin: 0 auto;
+  max-width: 1280px;
   padding: 1rem 2rem;
 }
 .brand { color: #e6edf7; font-weight: 800; text-decoration: none; }
-header span, .eyebrow { color: #75d7ff; font-size: .78rem; letter-spacing: .12em; }
+nav { display: flex; gap: 1.25rem; margin-right: auto; }
+nav a, .text-link { color: #b7c4d8; text-decoration: none; }
+nav a:hover, .text-link:hover { color: #75d7ff; }
+.environment-badge, .eyebrow { color: #75d7ff; font-size: .78rem; letter-spacing: .12em; }
 main { margin: 0 auto; max-width: 1180px; padding: 4rem 1.5rem; }
 h1 { font-size: clamp(2rem, 7vw, 4.5rem); line-height: 1; }
 h2 { margin-top: 2rem; }
@@ -30,7 +36,7 @@ input, select {
   padding: .8rem;
   width: 100%;
 }
-input:focus, select:focus, button:focus-visible, .button:focus-visible, .brand:focus-visible {
+input:focus, select:focus, button:focus-visible, .button:focus-visible, .brand:focus-visible, nav a:focus-visible, .text-link:focus-visible {
   outline: 3px solid rgba(117, 215, 255, .35);
   outline-offset: 2px;
 }
@@ -128,8 +134,48 @@ pre { background: #101d30; border-radius: .5rem; overflow: auto; padding: 1rem; 
 .run-summary { background: #101d30; border-radius: .65rem; grid-template-columns: 8rem 1fr; margin: 0; padding: 1rem; }
 .primary-action { background: #79e5aa; font-size: 1rem; padding: 1rem 1.3rem; }
 
+.portal-home { display: grid; gap: 2.5rem; }
+.portal-hero {
+  align-items: stretch;
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: minmax(0, 1fr) minmax(16rem, 22rem);
+}
+.portal-hero h1 { margin: .75rem 0 1rem; max-width: 11ch; }
+.hero-copy { font-size: 1.1rem; max-width: 62ch; }
+.hero-actions, .page-actions { align-items: center; display: flex; flex-wrap: wrap; gap: 1rem; margin-top: 1.5rem; }
+.portal-status-card, .portal-card {
+  background: linear-gradient(145deg, #0d1b2d, #0b1625);
+  border: 1px solid #29425e;
+  border-radius: .9rem;
+  padding: 1.25rem;
+}
+.portal-status-card strong { color: #79e5aa; display: block; font-size: 1.35rem; margin: .75rem 0 1.25rem; }
+.portal-status-card dl { font-size: .92rem; grid-template-columns: 7rem 1fr; }
+.portal-grid { display: grid; gap: 1rem; grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.portal-card { min-height: 12rem; }
+.portal-card h2 { margin: .8rem 0 .5rem; }
+.portal-card p { margin: 0; }
+.card-number { color: #75d7ff; font-size: .8rem; font-weight: 800; letter-spacing: .12em; }
+.guardrail-banner { background: #14263a; border: 1px solid #2d607c; border-radius: .7rem; color: #b7c4d8; padding: 1rem 1.1rem; }
+.guardrail-banner strong { color: #75d7ff; }
+.empty-state-page, .receipt-page, .run-page { max-width: 840px; }
+.page-intro { margin-top: -.5rem; }
+.run-heading { align-items: center; display: flex; gap: 1.25rem; justify-content: space-between; }
+.run-heading h1 { margin-bottom: .75rem; overflow-wrap: anywhere; }
+.status-badge { border: 1px solid; border-radius: 999px; font-size: .78rem; font-weight: 800; letter-spacing: .06em; padding: .5rem .75rem; white-space: nowrap; }
+.status-completed { background: #143025; border-color: #397a5c; color: #bff3d3; }
+.status-review-required { background: #332c18; border-color: #897039; color: #ffe8a8; }
+.status-denied, .status-failed-precheck, .status-failed-execution, .status-failed-validation { background: #391c24; border-color: #8e4354; color: #ffd1da; }
+.status-queued, .status-running, .status-in-progress, .status-pending, .status-unknown { background: #10283a; border-color: #2f6f86; color: #75d7ff; }
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { scroll-behavior: auto !important; transition-duration: .01ms !important; animation-duration: .01ms !important; }
+}
+
 @media (max-width: 760px) {
-  header { align-items: flex-start; flex-direction: column; gap: .5rem; padding: 1rem; }
+  .header-inner { align-items: flex-start; flex-direction: column; gap: .75rem; padding: 1rem; }
+  nav { flex-wrap: wrap; margin-right: 0; }
   main { padding: 2.5rem 1rem; }
   .workflow-hero, .workflow-steps { grid-template-columns: 1fr; }
   .workflow-hero { align-items: start; }
@@ -137,5 +183,7 @@ pre { background: #101d30; border-radius: .5rem; overflow: auto; padding: 1rem; 
   .final-step { grid-column: auto; }
   .run-summary, dl { grid-template-columns: 1fr; }
   .run-summary dd, dd { margin-bottom: .5rem; }
+  .portal-hero, .portal-grid { grid-template-columns: 1fr; }
+  .run-heading { align-items: flex-start; flex-direction: column; }
 }
 

--- a/apps/web/src/app/workflow/workflow-client.js
+++ b/apps/web/src/app/workflow/workflow-client.js
@@ -138,7 +138,7 @@ export default function OperatorWorkflow({ initialData }) {
     <div className="operator-workflow" aria-busy={disabled}>
       {notice ? <div className={`notice ${notice.type}`} role={notice.type === "error" ? "alert" : "status"}>{notice.text}</div> : null}
 
-      <ol className="workflow-steps">
+      <ol id="workflow-steps" className="workflow-steps">
         <li className="workflow-card">
           <div className="step-heading"><span>1</span><div><h2>Project</h2><p>Choose an existing project or create a synthetic one.</p></div></div>
           <label>


### PR DESCRIPTION
## Summary
- add a clear MOCK-only operator portal entry point
- remove manual resource ID entry from the legacy new-run route
- add automatic active-run status refresh through the server-side BFF
- improve receipt navigation, responsive layout, and accessibility states

## Validation
- npm test (12/12 passing)
- npm run build (passing)
- git diff --check (passing)

No Azure, Terraform, GHCR, production data, or pre-existing local receipts were changed.