### PR TITLE
feat(web): add bounded run progress UX

### DIFF
--- a/apps/web/src/app/api/runs/[runId]/route.js
+++ b/apps/web/src/app/api/runs/[runId]/route.js
@@ -12,7 +12,15 @@ export async function GET(_request, { params }) {
     });
   } catch {
     return NextResponse.json(
-      { error: { code: "RUN_STATUS_UNAVAILABLE", message: "Unable to load run status." } },
+      {
+        error: {
+          code: "RUN_STATUS_UNAVAILABLE",
+          message: "The Core service is temporarily unavailable.",
+          stage: "RUN_STATUS",
+          retryable: true,
+          correlation_id: null,
+        },
+      },
       { status: 502, headers: { "Cache-Control": "no-store" } },
     );
   }

--- a/apps/web/src/app/runs/[runId]/run-status-client.js
+++ b/apps/web/src/app/runs/[runId]/run-status-client.js
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 const TERMINAL_STATUSES = new Set([
   "COMPLETED",
@@ -10,47 +10,115 @@ const TERMINAL_STATUSES = new Set([
   "FAILED_PRECHECK",
   "FAILED_EXECUTION",
   "FAILED_VALIDATION",
+  "FAILED_RECEIPT",
 ]);
+
+const LIFECYCLE_STAGES = [
+  "CONTEXT",
+  "SYNC",
+  "PRECHECK",
+  "EXECUTION",
+  "AUTOMATED_VALIDATION",
+  "REVIEW_POLICY",
+  "RECEIPT",
+];
+
+const MAX_AUTO_REFRESHES = 12;
+const BASE_REFRESH_DELAY_MS = 3000;
+const MAX_REFRESH_DELAY_MS = 15000;
+
+function safeFailure(error, fallback = "The Core service is temporarily unavailable.") {
+  const failure = error?.failure ?? {};
+  return {
+    message: typeof failure.message === "string" ? failure.message : fallback,
+    code: typeof failure.code === "string" ? failure.code : "RUN_STATUS_UNAVAILABLE",
+    stage: typeof failure.stage === "string" ? failure.stage : "RUN_STATUS",
+    retryable: failure.retryable !== false,
+    correlationId: typeof failure.correlation_id === "string" ? failure.correlation_id : null,
+  };
+}
+
+function terminalError(run) {
+  const lifecycle = run?.metadata?.lifecycle ?? {};
+  const stageResults = run?.metadata?.stage_results ?? {};
+  const failedStage = LIFECYCLE_STAGES.find((stage) => ["FAIL", "FAILED"].includes(lifecycle[stage]));
+  const details = failedStage ? stageResults[failedStage] ?? {} : {};
+  if (!failedStage && !run?.error && !String(run?.status ?? "").startsWith("FAILED")) return null;
+  const code = run?.error?.code ?? details.code;
+  const stage = run?.error?.stage ?? failedStage;
+  return {
+    code: typeof code === "string" ? code : run?.status ?? "RUN_TERMINAL_FAILURE",
+    stage: typeof stage === "string" ? stage : "RUN_STATUS",
+    retryable: run?.error?.retryable === true || details.retryable === true,
+    correlationId: typeof run?.error?.correlation_id === "string" ? run.error.correlation_id : null,
+  };
+}
+
+function currentStage(run) {
+  const lifecycle = run?.metadata?.lifecycle ?? {};
+  const failed = LIFECYCLE_STAGES.find((stage) => ["FAIL", "FAILED"].includes(lifecycle[stage]));
+  if (failed) return failed;
+  const active = LIFECYCLE_STAGES.find((stage) => lifecycle[stage] !== "PASS");
+  return active ?? (run?.status === "COMPLETED" ? "RECEIPT" : "RUN_STATUS");
+}
+
+function stageClass(value) {
+  if (["PASS", "COMPLETED"].includes(value)) return "lifecycle-pass";
+  if (["FAIL", "FAILED"].includes(value)) return "lifecycle-fail";
+  return "lifecycle-pending";
+}
 
 export default function RunStatusClient({ runId, initialRun }) {
   const [run, setRun] = useState(initialRun);
-  const [refreshError, setRefreshError] = useState("");
+  const [refreshFailure, setRefreshFailure] = useState(null);
   const [refreshing, setRefreshing] = useState(false);
+  const [autoRefreshes, setAutoRefreshes] = useState(0);
+  const [pollingEnabled, setPollingEnabled] = useState(true);
   const terminal = useMemo(() => TERMINAL_STATUSES.has(run?.status), [run?.status]);
+  const exhausted = !terminal && autoRefreshes >= MAX_AUTO_REFRESHES;
+
+  const refresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      const response = await fetch(`/api/runs/${encodeURIComponent(runId)}`, {
+        cache: "no-store",
+        headers: { Accept: "application/json" },
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        const error = new Error(payload?.error?.message);
+        error.failure = payload?.error;
+        throw error;
+      }
+      setRun(payload);
+      setRefreshFailure(null);
+      setAutoRefreshes((count) => count + 1);
+    } catch (error) {
+      setRefreshFailure(safeFailure(error));
+      setAutoRefreshes((count) => count + 1);
+    } finally {
+      setRefreshing(false);
+    }
+  }, [runId]);
 
   useEffect(() => {
-    if (terminal) return undefined;
+    if (terminal || !pollingEnabled || exhausted) return undefined;
+    const delay = Math.min(BASE_REFRESH_DELAY_MS * 2 ** Math.min(autoRefreshes, 3), MAX_REFRESH_DELAY_MS);
+    const timeout = window.setTimeout(refresh, delay);
+    return () => window.clearTimeout(timeout);
+  }, [autoRefreshes, exhausted, pollingEnabled, refresh, terminal]);
 
-    let cancelled = false;
-    const refresh = async () => {
-      setRefreshing(true);
-      try {
-        const response = await fetch(`/api/runs/${encodeURIComponent(runId)}`, {
-          cache: "no-store",
-          headers: { Accept: "application/json" },
-        });
-        if (!response.ok) throw new Error("Unable to refresh run status.");
-        const nextRun = await response.json();
-        if (!cancelled) {
-          setRun(nextRun);
-          setRefreshError("");
-        }
-      } catch (error) {
-        if (!cancelled) setRefreshError(error.message);
-      } finally {
-        if (!cancelled) setRefreshing(false);
-      }
-    };
-
-    const interval = window.setInterval(refresh, 3000);
-    return () => {
-      cancelled = true;
-      window.clearInterval(interval);
-    };
-  }, [runId, terminal]);
+  const retryStatus = () => {
+    setRefreshFailure(null);
+    setAutoRefreshes(0);
+    setPollingEnabled(true);
+    void refresh();
+  };
 
   const status = run?.status ?? "UNKNOWN";
   const statusClass = `status-badge status-${status.toLowerCase().replaceAll("_", "-")}`;
+  const lifecycle = run?.metadata?.lifecycle ?? {};
+  const runError = terminal ? terminalError(run) : null;
 
   return (
     <section className="run-page">
@@ -58,16 +126,48 @@ export default function RunStatusClient({ runId, initialRun }) {
       <div className="run-heading">
         <div>
           <h1>{run?.run_id ?? runId}</h1>
-          <p className="page-intro">The portal refreshes active runs automatically.</p>
+          <p className="page-intro">Active runs refresh with bounded backoff through the Web BFF.</p>
         </div>
         <span className={statusClass} aria-live="polite">{status}</span>
       </div>
+
       <dl className="run-summary">
         <dt>Job</dt><dd>{run?.job_status ?? "UNAVAILABLE"}</dd>
         <dt>Mode</dt><dd>{run?.mode ?? "MOCK"}</dd>
-        <dt>Refresh</dt><dd>{terminal ? "Complete" : refreshing ? "Checking…" : "Every 3 seconds"}</dd>
+        <dt>Attempts</dt><dd>{run?.attempts ?? "UNAVAILABLE"}</dd>
+        <dt>Stage</dt><dd>{currentStage(run)}</dd>
+        <dt>Refresh</dt><dd>{terminal ? "Complete" : exhausted ? "Paused · retry available" : refreshing ? "Checking…" : "Bounded backoff"}</dd>
       </dl>
-      {refreshError ? <p className="notice error" role="status">{refreshError} We will retry automatically.</p> : null}
+
+      <section className="lifecycle-panel" aria-labelledby="lifecycle-heading">
+        <div className="section-heading">
+          <h2 id="lifecycle-heading">Lifecycle</h2>
+          <span>{run?.job_status ?? status}</span>
+        </div>
+        <ol className="lifecycle-map">
+          {LIFECYCLE_STAGES.map((stage) => {
+            const value = lifecycle[stage] ?? "PENDING";
+            return <li key={stage} className={stageClass(value)}><span>{stage.replaceAll("_", " ")}</span><strong>{value}</strong></li>;
+          })}
+        </ol>
+      </section>
+
+      {refreshFailure ? (
+        <div className="notice error error-details" role="status">
+          <strong>{refreshFailure.message}</strong>
+          <span>Code: {refreshFailure.code} · Stage: {refreshFailure.stage} · Retryable: {refreshFailure.retryable ? "yes" : "no"}</span>
+          {refreshFailure.correlationId ? <span>Correlation: {refreshFailure.correlationId}</span> : null}
+          <button type="button" onClick={retryStatus}>Retry status check</button>
+        </div>
+      ) : null}
+
+      {runError ? (
+        <div className={`notice ${runError.retryable ? "error" : "warning"}`} role="status">
+          <strong>{status === "REVIEW_REQUIRED" ? "Review required by policy." : "Run reached a terminal state."}</strong>
+          <span>Code: {runError.code} · Stage: {runError.stage} · Retryable: {runError.retryable ? "yes" : "no"}</span>
+        </div>
+      ) : null}
+
       {terminal ? (
         <div className="page-actions">
           <Link className="button" href={`/receipts/${encodeURIComponent(run.run_id)}`}>
@@ -76,7 +176,10 @@ export default function RunStatusClient({ runId, initialRun }) {
           <Link className="text-link" href="/workflow">Start another run</Link>
         </div>
       ) : (
-        <p className="loading-panel" role="status">The worker is processing this run. Keep this page open to follow the transition.</p>
+        <div className="loading-panel" role="status">
+          <span>{exhausted ? "Automatic checks are paused after the bounded retry window." : "The worker is processing this run; the page will continue checking."}</span>
+          <button type="button" onClick={retryStatus}>Refresh status</button>
+        </div>
       )}
     </section>
   );

--- a/apps/web/src/app/styles.css
+++ b/apps/web/src/app/styles.css
@@ -168,6 +168,23 @@ pre { background: #101d30; border-radius: .5rem; overflow: auto; padding: 1rem; 
 .status-review-required { background: #332c18; border-color: #897039; color: #ffe8a8; }
 .status-denied, .status-failed-precheck, .status-failed-execution, .status-failed-validation { background: #391c24; border-color: #8e4354; color: #ffd1da; }
 .status-queued, .status-running, .status-in-progress, .status-pending, .status-unknown { background: #10283a; border-color: #2f6f86; color: #75d7ff; }
+.status-failed-receipt { background: #391c24; border-color: #8e4354; color: #ffd1da; }
+.status-queued-dispatch-pending { background: #332c18; border-color: #897039; color: #ffe8a8; }
+.lifecycle-panel { background: #0d1929; border: 1px solid #24334a; border-radius: .9rem; margin-top: 1.5rem; padding: 1.25rem; }
+.section-heading { align-items: center; display: flex; justify-content: space-between; }
+.section-heading h2 { margin: 0; }
+.section-heading span { color: #8fa3bf; font-size: .82rem; }
+.lifecycle-map { display: grid; gap: .6rem; grid-template-columns: repeat(7, minmax(0, 1fr)); list-style: none; margin: 1.25rem 0 0; padding: 0; }
+.lifecycle-map li { border: 1px solid #334968; border-radius: .55rem; display: grid; gap: .4rem; min-height: 4.5rem; padding: .65rem; }
+.lifecycle-map li span { color: #b7c4d8; font-size: .7rem; line-height: 1.25; text-transform: uppercase; }
+.lifecycle-map li strong { font-size: .75rem; }
+.lifecycle-pass { background: #143025; border-color: #397a5c !important; color: #bff3d3; }
+.lifecycle-fail { background: #391c24; border-color: #8e4354 !important; color: #ffd1da; }
+.lifecycle-pending { background: #101d30; color: #8fa3bf; }
+.error-details { display: grid; gap: .45rem; margin-top: 1rem; }
+.error-details span, .notice.warning span { color: inherit; display: block; }
+.notice.warning { background: #332c18; border: 1px solid #897039; color: #ffe8a8; }
+.notice button, .loading-panel button { justify-self: start; margin-top: .3rem; }
 
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after { scroll-behavior: auto !important; transition-duration: .01ms !important; animation-duration: .01ms !important; }
@@ -185,5 +202,10 @@ pre { background: #101d30; border-radius: .5rem; overflow: auto; padding: 1rem; 
   .run-summary dd, dd { margin-bottom: .5rem; }
   .portal-hero, .portal-grid { grid-template-columns: 1fr; }
   .run-heading { align-items: flex-start; flex-direction: column; }
+  .lifecycle-map { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+@media (max-width: 420px) {
+  .lifecycle-map { grid-template-columns: 1fr; }
 }
 

--- a/apps/web/tests/operator-workflow.test.mjs
+++ b/apps/web/tests/operator-workflow.test.mjs
@@ -171,6 +171,19 @@ test("operator UI uses the Web BFF and does not expose manual resource ID inputs
   assert.equal(styles.includes("@media (max-width: 760px)"), true);
 });
 
+test("run status UI has bounded polling and lifecycle visibility", () => {
+  const appRoot = path.resolve(import.meta.dirname, "../src/app");
+  const source = fs.readFileSync(path.join(appRoot, "runs/[runId]/run-status-client.js"), "utf8");
+  const route = fs.readFileSync(path.join(appRoot, "api/runs/[runId]/route.js"), "utf8");
+  assert.equal(source.includes("MAX_AUTO_REFRESHES = 12"), true);
+  assert.equal(source.includes("MAX_REFRESH_DELAY_MS = 15000"), true);
+  assert.equal(source.includes("Retry status check"), true);
+  assert.equal(source.includes("lifecycle-map"), true);
+  assert.equal(source.includes("correlationId"), true);
+  assert.equal(route.includes("RUN_STATUS_UNAVAILABLE"), true);
+  assert.equal(route.includes("retryable: true"), true);
+});
+
 test("idempotency key derivation is stable and rejects malformed request IDs", () => {
   assert.equal(
     workflowIdempotencyKey("create_context", "request_same_123"),


### PR DESCRIPTION
Closes #11

## Summary
- show queued, running, review-required, completed and failed run states
- expose lifecycle stage, job status and attempts from canonical Core data
- add bounded Web/BFF polling with manual retry and cold-start tolerant messaging
- surface sanitized code, stage, retryable and correlation metadata

## Validation
- npm test (13/13 passing)
- npm run build (passing)
- git diff --check (passing)

No Azure, Terraform, GHCR, production data, or local receipts were changed.