### PR TITLE
feat(web): add context inspector

### DIFF
--- a/apps/web/src/app/api/operator/context-inspector/[capsuleId]/route.js
+++ b/apps/web/src/app/api/operator/context-inspector/[capsuleId]/route.js
@@ -1,0 +1,17 @@
+import {
+  loadContextInspector,
+  publicContextInspectorError,
+} from "../../../../../server/context-inspector.mjs";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(_request, { params }) {
+  try {
+    const { capsuleId } = await params;
+    const data = await loadContextInspector(capsuleId);
+    return Response.json(data, { headers: { "Cache-Control": "no-store" } });
+  } catch (error) {
+    const failure = publicContextInspectorError(error);
+    return Response.json({ error: failure.error }, { status: failure.status });
+  }
+}

--- a/apps/web/src/app/context-inspector/[capsuleId]/context-inspector-client.js
+++ b/apps/web/src/app/context-inspector/[capsuleId]/context-inspector-client.js
@@ -1,0 +1,61 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+
+function Field({ label, value }) {
+  return <><dt>{label}</dt><dd>{value ?? "—"}</dd></>;
+}
+
+export default function ContextInspectorClient({ capsuleId }) {
+  const [data, setData] = useState(null);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const response = await fetch(`/api/operator/context-inspector/${encodeURIComponent(capsuleId)}`, {
+        cache: "no-store",
+        headers: { Accept: "application/json" },
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error(payload?.error?.message ?? "The context inspector could not be loaded.");
+      setData(payload);
+    } catch (failure) {
+      setError(failure.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [capsuleId]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  if (loading) {
+    return <section className="inspector-page"><p className="eyebrow">Context Inspector</p><h1>Loading capsule…</h1><p className="loading-panel" role="status">Reading metadata through the Web BFF.</p></section>;
+  }
+  if (error) {
+    return <section className="inspector-page"><p className="eyebrow">Context Inspector</p><h1>Unable to load capsule</h1><p className="notice error" role="alert">{error}</p><div className="page-actions"><button type="button" onClick={() => void load()}>Retry</button><Link className="text-link" href="/workflow">Back to workflow</Link></div></section>;
+  }
+
+  const { capsule, context, binding, integrity, evidence } = data;
+  return (
+    <section className="inspector-page">
+      <p className="eyebrow">Context Inspector · Read only</p>
+      <div className="run-heading"><div><h1>{capsule.context_capsule_id}</h1><p className="page-intro">Metadata-first view of the immutable runtime snapshot.</p></div><span className="status-badge status-completed">IMMUTABLE</span></div>
+
+      <div className="inspector-integrity" role="status"><strong>Integrity verified</strong><span>Input hash {integrity.input_hash_present ? "present" : "missing"} · Profile binding {integrity.profile_bound ? "present" : "missing"}</span></div>
+
+      <div className="inspector-grid">
+        <section className="inspector-card"><h2>Capsule</h2><dl><Field label="Context ID" value={capsule.context_id} /><Field label="Schema" value={capsule.schema_version} /><Field label="Input hash" value={capsule.input_hash} /><Field label="Created" value={capsule.created_at} /></dl></section>
+        <section className="inspector-card"><h2>Context</h2><dl><Field label="Label" value={context.label} /><Field label="Project ID" value={context.project_id} /><Field label="Corpus ID" value={context.corpus_id} /><Field label="Type" value={context.context_type} /></dl></section>
+        <section className="inspector-card"><h2>Runtime binding</h2><dl><Field label="Profile" value={binding.analysis_profile_id} /><Field label="Version" value={binding.analysis_profile_version} /><Field label="Purpose" value={binding.purpose} /><Field label="Synthetic only" value={binding.synthetic_only ? "Yes" : "No"} /></dl></section>
+      </div>
+
+      <section className="inspector-card"><div className="section-heading"><h2>Evidence references</h2><span>{binding.evidence_refs} linked</span></div>{evidence.length === 0 ? <p className="empty-state">No evidence references are attached to this capsule.</p> : <ul className="evidence-list">{evidence.map((item) => <li key={item.evidence_ref_id}><strong>{item.evidence_ref_id}</strong><span>{item.evidence_state ?? "State unavailable"} · {item.availability}</span>{item.locator ? <small>{item.locator}</small> : null}</li>)}</ul>}</section>
+
+      <div className="page-actions"><Link className="button" href="/workflow">Back to workflow</Link><Link className="text-link" href={`/runs/new`}>Start a run</Link></div>
+    </section>
+  );
+}

--- a/apps/web/src/app/context-inspector/[capsuleId]/page.js
+++ b/apps/web/src/app/context-inspector/[capsuleId]/page.js
@@ -1,0 +1,6 @@
+import ContextInspectorClient from "./context-inspector-client";
+
+export default async function ContextInspectorPage({ params }) {
+  const { capsuleId } = await params;
+  return <ContextInspectorClient capsuleId={capsuleId} />;
+}

--- a/apps/web/src/app/styles.css
+++ b/apps/web/src/app/styles.css
@@ -185,6 +185,19 @@ pre { background: #101d30; border-radius: .5rem; overflow: auto; padding: 1rem; 
 .error-details span, .notice.warning span { color: inherit; display: block; }
 .notice.warning { background: #332c18; border: 1px solid #897039; color: #ffe8a8; }
 .notice button, .loading-panel button { justify-self: start; margin-top: .3rem; }
+.inspector-page { display: grid; gap: 1.25rem; max-width: 1080px; }
+.inspector-integrity { background: #143025; border: 1px solid #397a5c; border-radius: .7rem; display: grid; gap: .25rem; padding: 1rem 1.1rem; }
+.inspector-integrity strong { color: #bff3d3; }
+.inspector-integrity span { color: #b7c4d8; }
+.inspector-grid { display: grid; gap: 1rem; grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.inspector-card { background: #0d1929; border: 1px solid #24334a; border-radius: .9rem; padding: 1.15rem; }
+.inspector-card h2 { margin: 0 0 1rem; }
+.inspector-card dl { font-size: .92rem; grid-template-columns: 7rem 1fr; }
+.inspector-card dd { overflow-wrap: anywhere; }
+.evidence-list { display: grid; gap: .65rem; list-style: none; margin: 1rem 0 0; padding: 0; }
+.evidence-list li { background: #101d30; border: 1px solid #334968; border-radius: .6rem; display: grid; gap: .25rem; padding: .75rem; }
+.evidence-list li strong { color: #75d7ff; overflow-wrap: anywhere; }
+.evidence-list li span, .evidence-list li small { color: #b7c4d8; }
 
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after { scroll-behavior: auto !important; transition-duration: .01ms !important; animation-duration: .01ms !important; }
@@ -203,6 +216,7 @@ pre { background: #101d30; border-radius: .5rem; overflow: auto; padding: 1rem; 
   .portal-hero, .portal-grid { grid-template-columns: 1fr; }
   .run-heading { align-items: flex-start; flex-direction: column; }
   .lifecycle-map { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .inspector-grid { grid-template-columns: 1fr; }
 }
 
 @media (max-width: 420px) {

--- a/apps/web/src/app/workflow/workflow-client.js
+++ b/apps/web/src/app/workflow/workflow-client.js
@@ -2,6 +2,7 @@
 
 import { useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 
 const EMPTY_SELECTION = {
   projectId: "",
@@ -223,6 +224,7 @@ export default function OperatorWorkflow({ initialData }) {
           </label>
           {technicalId("Capsule ID", capsule?.context_capsule_id)}
           {capsule ? technicalId("Input hash", capsule.input_hash) : null}
+          {capsule ? <Link className="text-link" href={`/context-inspector/${encodeURIComponent(capsule.context_capsule_id)}`}>Inspect immutable capsule</Link> : null}
           {profile ? <small className="technical-id">New snapshots bind the profile <strong>{profile.name ?? profile.analysis_profile_id}</strong> selected in step 5.</small> : null}
           {selection.contextId && data.capsules.length === 0 ? <p className="empty-state">No snapshots exist for this context.</p> : null}
           <button

--- a/apps/web/src/server/context-inspector.mjs
+++ b/apps/web/src/server/context-inspector.mjs
@@ -1,0 +1,110 @@
+import { CoreApiError, coreRequest } from "./core-client.mjs";
+
+const CAPSULE_ID_PATTERN = /^cap_[A-Za-z0-9_-]+$/;
+
+export class ContextInspectorValidationError extends Error {
+  constructor(message = "The context capsule identifier is invalid.") {
+    super(message);
+    this.name = "ContextInspectorValidationError";
+    this.code = "CONTEXT_CAPSULE_INVALID";
+    this.status = 400;
+  }
+}
+
+function text(value) {
+  return typeof value === "string" ? value : null;
+}
+
+function evidenceSummary(refId, metadata, error) {
+  if (error || !metadata) {
+    return { evidence_ref_id: refId, availability: "UNAVAILABLE" };
+  }
+  return {
+    evidence_ref_id: refId,
+    availability: text(metadata.content_availability) ?? "METADATA_ONLY",
+    evidence_state: text(metadata.evidence_state),
+    evidence_state_snapshot: text(metadata.evidence_state_snapshot),
+    modality: text(metadata.modality),
+    locator: text(metadata.locator),
+    excerpt_hash: text(metadata.excerpt_hash),
+    content_sha256: text(metadata.content_sha256),
+  };
+}
+
+export async function loadContextInspector(
+  capsuleId,
+  { coreRequestImpl = coreRequest } = {},
+) {
+  const normalizedId = String(capsuleId ?? "").trim();
+  if (!CAPSULE_ID_PATTERN.test(normalizedId)) throw new ContextInspectorValidationError();
+
+  const capsule = await coreRequestImpl(`/v1/context-capsules/${encodeURIComponent(normalizedId)}`);
+  const payload = capsule?.payload ?? {};
+  const context = await coreRequestImpl(
+    `/v1/contexts/${encodeURIComponent(capsule.context_id)}`,
+  );
+  const evidenceRefs = Array.isArray(payload.evidence_refs) ? payload.evidence_refs : [];
+  const evidenceResults = await Promise.all(
+    evidenceRefs.map(async (refId) => {
+      try {
+        return evidenceSummary(refId, await coreRequestImpl(`/v1/evidence/${encodeURIComponent(refId)}`));
+      } catch (error) {
+        if (!(error instanceof CoreApiError)) throw error;
+        return evidenceSummary(refId, null, error);
+      }
+    }),
+  );
+
+  return {
+    capsule: {
+      context_capsule_id: text(capsule.context_capsule_id),
+      context_id: text(capsule.context_id),
+      schema_version: text(capsule.schema_version),
+      input_hash: text(capsule.input_hash),
+      created_at: text(capsule.created_at),
+    },
+    context: {
+      context_id: text(context.context_id),
+      project_id: text(context.project_id),
+      context_type: text(context.context_type),
+      valid_from: text(context.valid_from),
+      valid_until: text(context.valid_until),
+      label: text(context.dimensions?.label),
+      corpus_id: text(context.dimensions?.corpus_id),
+    },
+    binding: {
+      analysis_profile_id: text(payload.analysis_profile_id),
+      analysis_profile_version: text(payload.analysis_profile_version),
+      purpose: text(payload.purpose),
+      synthetic_only: payload.synthetic_only === true,
+      identity_refs: Array.isArray(payload.identity_refs) ? payload.identity_refs.length : 0,
+      evidence_refs: evidenceRefs.length,
+    },
+    integrity: {
+      immutable: true,
+      input_hash_present: Boolean(capsule.input_hash),
+      profile_bound: Boolean(payload.analysis_profile_id && payload.analysis_profile_version),
+    },
+    evidence: evidenceResults,
+  };
+}
+
+export function publicContextInspectorError(error) {
+  if (error instanceof ContextInspectorValidationError) {
+    return { status: error.status, error: { code: error.code, message: error.message } };
+  }
+  if (error instanceof CoreApiError) {
+    const status = error.status >= 400 && error.status < 500 ? error.status : 502;
+    return {
+      status,
+      error: {
+        code: status === 502 ? "CONTEXT_INSPECTOR_UNAVAILABLE" : error.code,
+        message: status === 502 ? "The Core service is temporarily unavailable." : error.message,
+      },
+    };
+  }
+  return {
+    status: 500,
+    error: { code: "CONTEXT_INSPECTOR_FAILED", message: "The context inspector could not be loaded." },
+  };
+}

--- a/apps/web/tests/operator-workflow.test.mjs
+++ b/apps/web/tests/operator-workflow.test.mjs
@@ -10,6 +10,10 @@ import {
   publicOperatorError,
   workflowIdempotencyKey,
 } from "../src/server/operator-workflow.mjs";
+import {
+  loadContextInspector,
+  publicContextInspectorError,
+} from "../src/server/context-inspector.mjs";
 
 test("operator snapshot uses filtered Core read APIs through the server", async () => {
   const calls = [];
@@ -28,6 +32,56 @@ test("operator snapshot uses filtered Core read APIs through the server", async 
   assert.equal(snapshot.projects[0].project_id, "prj_one");
   assert.equal(snapshot.selectedCapsule.context_capsule_id, "cap_one");
   assert.deepEqual(calls.sort(), [...responses.keys()].sort());
+});
+
+test("context inspector reads capsule lineage and evidence metadata through the BFF", async () => {
+  const calls = [];
+  const responses = new Map([
+    ["/v1/context-capsules/cap_one", {
+      context_capsule_id: "cap_one",
+      context_id: "ctx_one",
+      schema_version: "P0-RUNTIME-1",
+      input_hash: "hash_one",
+      created_at: "2026-08-26T00:00:00Z",
+      payload: {
+        project_id: "prj_one",
+        analysis_profile_id: "AP-101",
+        analysis_profile_version: "1.0.0",
+        purpose: "Synthetic",
+        synthetic_only: true,
+        identity_refs: [],
+        evidence_refs: ["evref_one"],
+      },
+    }],
+    ["/v1/contexts/ctx_one", {
+      context_id: "ctx_one",
+      project_id: "prj_one",
+      context_type: "P1_SYNTHETIC_OPERATOR",
+      dimensions: { corpus_id: "cor_one", label: "Bounded context" },
+    }],
+    ["/v1/evidence/evref_one", {
+      evidence_ref_id: "evref_one",
+      evidence_state: "VERIFIED",
+      content_availability: "METADATA_ONLY",
+      modality: "TEXT",
+      locator: "synthetic://fixture/one",
+    }],
+  ]);
+  const snapshot = await loadContextInspector("cap_one", {
+    coreRequestImpl: async (requestPath) => { calls.push(requestPath); return responses.get(requestPath); },
+  });
+  assert.equal(snapshot.integrity.immutable, true);
+  assert.equal(snapshot.binding.analysis_profile_id, "AP-101");
+  assert.equal(snapshot.context.label, "Bounded context");
+  assert.equal(snapshot.evidence[0].evidence_state, "VERIFIED");
+  assert.deepEqual(calls.sort(), [...responses.keys()].sort());
+});
+
+test("context inspector rejects malformed capsule IDs without exposing internals", async () => {
+  await assert.rejects(() => loadContextInspector("cap one", { coreRequestImpl: async () => ({}) }));
+  const failure = publicContextInspectorError(new Error("secret connection string"));
+  assert.equal(failure.error.code, "CONTEXT_INSPECTOR_FAILED");
+  assert.equal(JSON.stringify(failure).includes("secret"), false);
 });
 
 test("operator project creation generates the ID server-side and sends idempotency", async () => {


### PR DESCRIPTION
Closes #12

## Summary
- add a read-only metadata-first Context Inspector for immutable capsules
- load capsule lineage, context binding, hashes and evidence metadata through the Web BFF
- surface safe loading, empty, error and retry states without raw payload exposure
- link the inspector directly from the guided operator workflow

## Validation
- npm test (15/15 passing)
- npm run build (passing)
- local smoke: / (200), /context-inspector/cap_invalid (200), invalid inspector API (400)
- git diff --check (passing)

No Azure, Terraform, GHCR, production data, or local receipts were changed.