### PR TITLE
feat(web): add runs history audit view

### DIFF
--- a/apps/web/src/app/api/operator/runs/route.js
+++ b/apps/web/src/app/api/operator/runs/route.js
@@ -1,0 +1,19 @@
+import { loadRunsHistory, publicRunsHistoryError } from "../../../../server/runs-history.mjs";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request) {
+  const url = new URL(request.url);
+  try {
+    const data = await loadRunsHistory({
+      status: url.searchParams.get("status") ?? "",
+      projectId: url.searchParams.get("project_id") ?? "",
+      profileId: url.searchParams.get("profile_id") ?? "",
+      limit: url.searchParams.get("limit") ?? "25",
+    });
+    return Response.json(data, { headers: { "Cache-Control": "no-store" } });
+  } catch (error) {
+    const failure = publicRunsHistoryError(error);
+    return Response.json({ error: failure.error }, { status: failure.status });
+  }
+}

--- a/apps/web/src/app/layout.js
+++ b/apps/web/src/app/layout.js
@@ -16,6 +16,7 @@ export default function RootLayout({ children }) {
             <nav aria-label="Primary navigation">
               <Link href="/">Portal</Link>
               <Link href="/workflow">Operator workflow</Link>
+              <Link href="/runs">Runs history</Link>
             </nav>
             <span className="environment-badge">MOCK · SYNTHETIC DATA ONLY</span>
           </div>

--- a/apps/web/src/app/runs/page.js
+++ b/apps/web/src/app/runs/page.js
@@ -1,0 +1,5 @@
+import RunsHistoryClient from "./runs-history-client";
+
+export default function RunsHistoryPage() {
+  return <RunsHistoryClient />;
+}

--- a/apps/web/src/app/runs/runs-history-client.js
+++ b/apps/web/src/app/runs/runs-history-client.js
@@ -1,0 +1,57 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+
+const STATUS_OPTIONS = ["", "QUEUED", "RUNNING", "REVIEW_REQUIRED", "COMPLETED", "DENIED", "FAILED_PRECHECK", "FAILED_EXECUTION", "FAILED_VALIDATION", "FAILED_RECEIPT"];
+const TERMINAL = new Set(STATUS_OPTIONS.slice(3));
+
+function formatDate(value) {
+  if (!value) return "—";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+}
+
+function statusClass(status) { return `status-badge status-${String(status ?? "unknown").toLowerCase().replaceAll("_", "-")}`; }
+
+export default function RunsHistoryClient() {
+  const [filters, setFilters] = useState({ status: "", project_id: "", profile_id: "" });
+  const [options, setOptions] = useState({ projects: [], profiles: [] });
+  const [runs, setRuns] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const load = useCallback(async (nextFilters = filters) => {
+    setLoading(true); setError("");
+    try {
+      const query = new URLSearchParams({ ...nextFilters, limit: "25" });
+      const response = await fetch(`/api/operator/runs?${query}`, { cache: "no-store", headers: { Accept: "application/json" } });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error(payload?.error?.message ?? "The run history could not be loaded.");
+      setRuns(Array.isArray(payload.runs) ? payload.runs : []);
+      setOptions(payload.filters ?? { projects: [], profiles: [] });
+    } catch (failure) { setError(failure.message); } finally { setLoading(false); }
+  }, [filters]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  function applyFilters(event) { event.preventDefault(); void load(filters); }
+
+  return <section className="history-page">
+    <div className="workflow-hero"><div><p className="eyebrow">Operator audit · Read only</p><h1>Runs history</h1><p>Locate prior synthetic runs without copying technical identifiers. Results are bounded to the 25 most recent records.</p></div><div className="mode-badge" aria-label="Provider mode MOCK"><span>Provider mode</span><strong>MOCK</strong></div></div>
+    <form className="history-filters" onSubmit={applyFilters} aria-label="Run history filters">
+      <label>Status<select value={filters.status} onChange={(event) => setFilters({ ...filters, status: event.target.value })}>{STATUS_OPTIONS.map((value) => <option key={value} value={value}>{value || "All statuses"}</option>)}</select></label>
+      <label>Project<select value={filters.project_id} onChange={(event) => setFilters({ ...filters, project_id: event.target.value })}><option value="">All projects</option>{options.projects.map((item) => <option key={item.project_id} value={item.project_id}>{item.name ?? item.project_id}</option>)}</select></label>
+      <label>Profile<select value={filters.profile_id} onChange={(event) => setFilters({ ...filters, profile_id: event.target.value })}><option value="">All profiles</option>{options.profiles.map((item) => <option key={`${item.analysis_profile_id}::${item.version}`} value={item.analysis_profile_id}>{item.name ?? item.analysis_profile_id} · {item.version}</option>)}</select></label>
+      <button type="submit" disabled={loading}>{loading ? "Loading…" : "Apply filters"}</button>
+    </form>
+    {error ? <div className="notice error" role="alert">{error}<button type="button" onClick={() => void load()}>Retry</button></div> : null}
+    {loading && !runs.length ? <p className="loading-panel" role="status">Loading recent runs through the Web BFF.</p> : null}
+    {!loading && !error && !runs.length ? <p className="empty-state">No runs match these filters.</p> : null}
+    {runs.length ? <div className="run-history-list" aria-live="polite">{runs.map((run) => <article className={`history-card ${TERMINAL.has(run.status) ? "terminal" : "active"}`} key={run.run_id}>
+      <div className="history-card-heading"><div><span className="history-state">{TERMINAL.has(run.status) ? "Terminal" : "Active"}</span><h2>{run.run_id}</h2></div><span className={statusClass(run.status)}>{run.status}</span></div>
+      <dl><dt>Job</dt><dd>{run.job_status ?? "—"}</dd><dt>Project</dt><dd>{run.project_id ?? "—"}</dd><dt>Profile</dt><dd>{run.analysis_profile_id ?? "—"} · {run.analysis_profile_version ?? "—"}</dd><dt>Attempts</dt><dd>{run.attempts ?? "—"}</dd><dt>Started</dt><dd>{formatDate(run.started_at)}</dd><dt>Completed</dt><dd>{formatDate(run.completed_at)}</dd><dt>Output</dt><dd>{run.output_status ?? (run.status === "REVIEW_REQUIRED" ? "REVIEW_REQUIRED" : "—")}</dd><dt>Review</dt><dd>{run.review_mode ?? "—"}</dd></dl>
+      <div className="page-actions"><Link className="button" href={`/runs/${encodeURIComponent(run.run_id)}`}>View status</Link>{run.context_capsule_id ? <Link className="text-link" href={`/context-inspector/${encodeURIComponent(run.context_capsule_id)}`}>Inspect capsule</Link> : null}{TERMINAL.has(run.status) ? <Link className="text-link" href={`/receipts/${encodeURIComponent(run.run_id)}`}>View receipt</Link> : null}</div>
+    </article>)}</div> : null}
+  </section>;
+}

--- a/apps/web/src/app/styles.css
+++ b/apps/web/src/app/styles.css
@@ -200,6 +200,17 @@ pre { background: #101d30; border-radius: .5rem; overflow: auto; padding: 1rem; 
 .evidence-list li a:hover { text-decoration: underline; }
 .evidence-list li strong { color: #75d7ff; overflow-wrap: anywhere; }
 .evidence-list li span, .evidence-list li small { color: #b7c4d8; }
+.history-page { display: grid; gap: 1.5rem; }
+.history-filters { align-items: end; background: #0d1929; border: 1px solid #24334a; border-radius: .9rem; display: grid; gap: 1rem; grid-template-columns: repeat(3, minmax(0, 1fr)) auto; padding: 1rem; }
+.history-filters button { min-height: 2.75rem; }
+.run-history-list { display: grid; gap: 1rem; }
+.history-card { background: #0d1929; border: 1px solid #24334a; border-radius: .9rem; padding: 1.25rem; }
+.history-card.active { border-color: #2f6f86; }
+.history-card.terminal { border-color: #397a5c; }
+.history-card-heading { align-items: start; display: flex; gap: 1rem; justify-content: space-between; }
+.history-card-heading h2 { font-size: 1.1rem; margin: .35rem 0 0; overflow-wrap: anywhere; }
+.history-state { color: #8fa3bf; font-size: .72rem; letter-spacing: .08em; text-transform: uppercase; }
+.history-card dl { grid-template-columns: 8rem 1fr; margin: 1rem 0 0; }
 
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after { scroll-behavior: auto !important; transition-duration: .01ms !important; animation-duration: .01ms !important; }
@@ -219,6 +230,7 @@ pre { background: #101d30; border-radius: .5rem; overflow: auto; padding: 1rem; 
   .run-heading { align-items: flex-start; flex-direction: column; }
   .lifecycle-map { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .inspector-grid { grid-template-columns: 1fr; }
+  .history-filters { grid-template-columns: 1fr; }
 }
 
 @media (max-width: 420px) {

--- a/apps/web/src/server/runs-history.mjs
+++ b/apps/web/src/server/runs-history.mjs
@@ -1,0 +1,85 @@
+import { CoreApiError, coreRequest } from "./core-client.mjs";
+
+const STATUS_VALUES = new Set([
+  "QUEUED", "RUNNING", "COMPLETED", "REVIEW_REQUIRED", "DENIED",
+  "FAILED_PRECHECK", "FAILED_EXECUTION", "FAILED_VALIDATION", "FAILED_RECEIPT",
+]);
+const MAX_LIMIT = 25;
+
+export class RunsHistoryValidationError extends Error {
+  constructor(message = "The run history filter is invalid.") {
+    super(message);
+    this.name = "RunsHistoryValidationError";
+    this.code = "RUN_HISTORY_FILTER_INVALID";
+    this.status = 400;
+  }
+}
+
+function safeText(value) { return typeof value === "string" ? value : null; }
+function safeId(value) {
+  const text = String(value ?? "").trim();
+  if (!text || text.length > 200 || !/^[A-Za-z0-9_.:-]+$/.test(text)) throw new RunsHistoryValidationError();
+  return text;
+}
+function isTerminal(status) { return ["COMPLETED", "REVIEW_REQUIRED", "DENIED", "FAILED_PRECHECK", "FAILED_EXECUTION", "FAILED_VALIDATION", "FAILED_RECEIPT"].includes(status); }
+
+export async function loadRunsHistory(
+  { status = "", projectId = "", profileId = "", limit = 25 } = {},
+  { coreRequestImpl = coreRequest } = {},
+) {
+  const normalizedStatus = String(status ?? "").trim();
+  if (normalizedStatus && !STATUS_VALUES.has(normalizedStatus)) throw new RunsHistoryValidationError("The run status filter is invalid.");
+  const normalizedProject = projectId ? safeId(projectId) : "";
+  const normalizedProfile = profileId ? safeId(profileId) : "";
+  const boundedLimit = Math.min(Math.max(Number.parseInt(limit, 10) || MAX_LIMIT, 1), MAX_LIMIT);
+  const query = new URLSearchParams({ limit: String(boundedLimit) });
+  if (normalizedStatus) query.set("status", normalizedStatus);
+  if (normalizedProject) query.set("project_id", normalizedProject);
+
+  const [runs, projects, profiles] = await Promise.all([
+    coreRequestImpl(`/v1/runs?${query}`),
+    coreRequestImpl("/v1/projects?limit=100"),
+    coreRequestImpl("/v1/analysis-profiles?limit=100"),
+  ]);
+  const filteredRuns = normalizedProfile
+    ? runs.filter((run) => run.analysis_profile_id === normalizedProfile)
+    : runs;
+  const enriched = await Promise.all(filteredRuns.map(async (run) => {
+    const detail = await coreRequestImpl(`/v1/runs/${encodeURIComponent(run.run_id)}`);
+    let receipt = null;
+    if (isTerminal(detail.status)) {
+      try { receipt = await coreRequestImpl(`/v1/runs/${encodeURIComponent(run.run_id)}/receipt`); } catch (error) { if (!(error instanceof CoreApiError)) throw error; }
+    }
+    return {
+      run_id: safeText(detail.run_id ?? run.run_id),
+      status: safeText(detail.status ?? run.status),
+      job_status: safeText(detail.job_status),
+      project_id: safeText(detail.project_id ?? run.project_id),
+      context_capsule_id: safeText(detail.context_capsule_id ?? run.context_capsule_id),
+      analysis_profile_id: safeText(detail.analysis_profile_id ?? run.analysis_profile_id),
+      analysis_profile_version: safeText(detail.analysis_profile_version ?? run.analysis_profile_version),
+      mode: safeText(detail.mode ?? run.mode),
+      started_at: safeText(detail.started_at ?? run.started_at),
+      completed_at: safeText(detail.completed_at ?? run.completed_at),
+      attempts: typeof detail.attempts === "number" ? detail.attempts : null,
+      output_status: safeText(receipt?.output_status),
+      review_mode: safeText(receipt?.review_mode),
+    };
+  }));
+  return {
+    runs: enriched,
+    filters: {
+      projects: projects.map((item) => ({ project_id: safeText(item.project_id), name: safeText(item.name) })),
+      profiles: profiles.map((item) => ({ analysis_profile_id: safeText(item.analysis_profile_id), version: safeText(item.version), name: safeText(item.name) })),
+    },
+  };
+}
+
+export function publicRunsHistoryError(error) {
+  if (error instanceof RunsHistoryValidationError) return { status: error.status, error: { code: error.code, message: error.message } };
+  if (error instanceof CoreApiError) {
+    const status = error.status >= 400 && error.status < 500 ? error.status : 502;
+    return { status, error: { code: status === 502 ? "RUN_HISTORY_UNAVAILABLE" : error.code, message: status === 502 ? "The Core service is temporarily unavailable." : error.message } };
+  }
+  return { status: 500, error: { code: "RUN_HISTORY_FAILED", message: "The run history could not be loaded." } };
+}

--- a/apps/web/tests/operator-workflow.test.mjs
+++ b/apps/web/tests/operator-workflow.test.mjs
@@ -18,6 +18,10 @@ import {
   loadEvidenceExplorer,
   publicEvidenceExplorerError,
 } from "../src/server/evidence-explorer.mjs";
+import {
+  loadRunsHistory,
+  publicRunsHistoryError,
+} from "../src/server/runs-history.mjs";
 
 test("operator snapshot uses filtered Core read APIs through the server", async () => {
   const calls = [];
@@ -114,6 +118,29 @@ test("evidence explorer errors are deterministic and sanitized", () => {
   const failure = publicEvidenceExplorerError(new Error("storage secret"));
   assert.equal(failure.status, 500);
   assert.equal(failure.error.code, "EVIDENCE_EXPLORER_FAILED");
+  assert.equal(JSON.stringify(failure).includes("secret"), false);
+});
+
+test("runs history applies bounded filters and exposes safe audit fields", async () => {
+  const calls = [];
+  const responses = new Map([
+    ["/v1/runs?limit=25&status=COMPLETED&project_id=prj_one", [{ run_id: "run_one", project_id: "prj_one", context_capsule_id: "cap_one", analysis_profile_id: "AP-101", analysis_profile_version: "1.0.0", status: "COMPLETED", mode: "MOCK" }]],
+    ["/v1/projects?limit=100", [{ project_id: "prj_one", name: "Synthetic" }]],
+    ["/v1/analysis-profiles?limit=100", [{ analysis_profile_id: "AP-101", version: "1.0.0", name: "Default" }]],
+    ["/v1/runs/run_one", { run_id: "run_one", project_id: "prj_one", context_capsule_id: "cap_one", analysis_profile_id: "AP-101", analysis_profile_version: "1.0.0", status: "COMPLETED", mode: "MOCK", job_status: "COMPLETED", attempts: 1, started_at: "2026-08-26T00:00:00Z", completed_at: "2026-08-26T00:01:00Z", metadata: { secret: "drop" } }],
+    ["/v1/runs/run_one/receipt", { output_status: "COMPLETED", review_mode: "NONE" }],
+  ]);
+  const result = await loadRunsHistory({ status: "COMPLETED", projectId: "prj_one", profileId: "AP-101" }, { coreRequestImpl: async (requestPath) => { calls.push(requestPath); return responses.get(requestPath); } });
+  assert.equal(result.runs[0].attempts, 1);
+  assert.equal(result.runs[0].output_status, "COMPLETED");
+  assert.equal(result.runs[0].metadata, undefined);
+  assert.equal(calls.includes("/v1/runs?limit=25&status=COMPLETED&project_id=prj_one"), true);
+});
+
+test("runs history rejects invalid filters without leaking internals", async () => {
+  await assert.rejects(() => loadRunsHistory({ status: "DROP TABLE" }, { coreRequestImpl: async () => [] }));
+  const failure = publicRunsHistoryError(new Error("connection secret"));
+  assert.equal(failure.error.code, "RUN_HISTORY_FAILED");
   assert.equal(JSON.stringify(failure).includes("secret"), false);
 });
 


### PR DESCRIPTION
Closes #14

## Summary
- add bounded read-only runs history with status, project and profile filters
- enrich recent runs with safe job, attempts, timestamps and terminal receipt status
- link run status, ContextReceipt and Context Inspector without manual identifiers
- keep all reads behind the Web BFF and preserve MOCK-only operation

## Validation
- npm test (19/19 passing)
- npm run build (passing)
- git diff --check (passing)

No Azure, Terraform, GHCR, production data, or local receipts were changed.