### PR TITLE
P1-SEC · Minimum OIDC/session/RBAC gate

### DIFF
--- a/apps/core/src/soaiacore_core/auth.py
+++ b/apps/core/src/soaiacore_core/auth.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import hmac
+import re
+import time
+
+
+_OPERATOR_ID_PATTERN = re.compile(r"^op_[a-f0-9]{24}$")
+_VALID_ROLES = {"OPERATOR", "ADMIN"}
+
+
+class OperatorAuthError(ValueError):
+    def __init__(self, code: str, message: str, status_code: int) -> None:
+        super().__init__(message)
+        self.code = code
+        self.status_code = status_code
+
+
+@dataclass(frozen=True)
+class OperatorContext:
+    operator_id: str
+    role: str
+    correlation_id: str
+
+
+def signature_payload(
+    *,
+    method: str,
+    path: str,
+    timestamp: str,
+    correlation_id: str,
+    operator_id: str,
+    role: str,
+    content_sha256: str,
+) -> bytes:
+    return "\n".join(
+        (method.upper(), path, timestamp, correlation_id, operator_id, role, content_sha256)
+    ).encode("utf-8")
+
+
+def sign_operator_context(
+    secret: str,
+    *,
+    method: str,
+    path: str,
+    timestamp: str,
+    correlation_id: str,
+    operator_id: str,
+    role: str,
+    content_sha256: str,
+) -> str:
+    return hmac.new(
+        secret.encode("utf-8"),
+        signature_payload(
+            method=method,
+            path=path,
+            timestamp=timestamp,
+            correlation_id=correlation_id,
+            operator_id=operator_id,
+            role=role,
+            content_sha256=content_sha256,
+        ),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def verify_operator_context(
+    secret: str | None,
+    *,
+    method: str,
+    path: str,
+    timestamp: str | None,
+    correlation_id: str | None,
+    operator_id: str | None,
+    role: str | None,
+    signature: str | None,
+    content_sha256: str | None,
+    actual_content_sha256: str,
+    now: int | None = None,
+    max_clock_skew_seconds: int = 120,
+) -> OperatorContext:
+    if not secret or len(secret.encode("utf-8")) < 32:
+        raise OperatorAuthError(
+            "INTERNAL_AUTH_NOT_CONFIGURED",
+            "The internal authorization boundary is unavailable",
+            503,
+        )
+    if not all((timestamp, correlation_id, operator_id, role, signature, content_sha256)):
+        raise OperatorAuthError(
+            "OPERATOR_AUTH_REQUIRED", "Authenticated operator context is required", 401
+        )
+    if not _OPERATOR_ID_PATTERN.fullmatch(operator_id or ""):
+        raise OperatorAuthError("OPERATOR_AUTH_INVALID", "Operator context is invalid", 401)
+    normalized_role = (role or "").upper()
+    if normalized_role not in _VALID_ROLES:
+        raise OperatorAuthError("OPERATOR_ROLE_FORBIDDEN", "Operator role is not allowed", 403)
+    if not correlation_id or len(correlation_id) > 100 or not all(
+        character.isalnum() or character in "_-" for character in correlation_id
+    ):
+        raise OperatorAuthError("OPERATOR_AUTH_INVALID", "Operator context is invalid", 401)
+    if not re.fullmatch(r"[a-f0-9]{64}", content_sha256 or "") or not hmac.compare_digest(
+        content_sha256 or "", actual_content_sha256
+    ):
+        raise OperatorAuthError("OPERATOR_AUTH_INVALID", "Operator context is invalid", 401)
+    try:
+        signed_at = int(timestamp or "")
+    except ValueError as exc:
+        raise OperatorAuthError("OPERATOR_AUTH_INVALID", "Operator context is invalid", 401) from exc
+    current = int(time.time()) if now is None else now
+    if abs(current - signed_at) > max_clock_skew_seconds:
+        raise OperatorAuthError("OPERATOR_AUTH_EXPIRED", "Operator context has expired", 401)
+    expected = sign_operator_context(
+        secret,
+        method=method,
+        path=path,
+        timestamp=str(signed_at),
+        correlation_id=correlation_id,
+        operator_id=operator_id,
+        role=normalized_role,
+        content_sha256=content_sha256 or "",
+    )
+    if not hmac.compare_digest(expected, signature or ""):
+        raise OperatorAuthError("OPERATOR_AUTH_INVALID", "Operator context is invalid", 401)
+    return OperatorContext(
+        operator_id=operator_id,
+        role=normalized_role,
+        correlation_id=correlation_id,
+    )

--- a/apps/core/src/soaiacore_core/main.py
+++ b/apps/core/src/soaiacore_core/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+import hashlib
 import uuid
 from typing import Any
 
@@ -45,6 +46,7 @@ from soaiacore_runtime.operations import (
 from soaiacore_runtime.schemas import validate_payload
 
 from .dispatcher import DispatchResult, build_dispatcher
+from .auth import OperatorAuthError, verify_operator_context
 from .models import (
     ContextCapsuleRequest,
     ContextRequest,
@@ -85,10 +87,51 @@ def _receipt_payload(row: dict[str, Any]) -> dict[str, Any]:
 def create_app(settings: RuntimeSettings | None = None) -> FastAPI:
     active_settings = settings or RuntimeSettings.from_env()
     database = Database(active_settings.database_url)
-    app = FastAPI(title="SOAIACORE Core", version="0.1.0")
+
+    async def require_operator(request: Request) -> None:
+        if not active_settings.internal_auth_required or not request.url.path.startswith("/v1/"):
+            return
+        try:
+            operator = verify_operator_context(
+                active_settings.internal_auth_secret,
+                method=request.method,
+                path=request.url.path + (f"?{request.url.query}" if request.url.query else ""),
+                timestamp=request.headers.get("X-SOAIA-Auth-Timestamp"),
+                correlation_id=request.headers.get("X-Correlation-ID"),
+                operator_id=request.headers.get("X-SOAIA-Operator-ID"),
+                role=request.headers.get("X-SOAIA-Operator-Role"),
+                signature=request.headers.get("X-SOAIA-Auth-Signature"),
+                content_sha256=request.headers.get("X-SOAIA-Content-SHA256"),
+                actual_content_sha256=hashlib.sha256(await request.body()).hexdigest(),
+            )
+        except OperatorAuthError as exc:
+            raise contract_error(
+                exc.code,
+                str(exc),
+                "AUTHORIZATION",
+                status_code=exc.status_code,
+                retryable=exc.status_code == 503,
+            ) from exc
+        request.state.operator = operator
+
+    app = FastAPI(
+        title="SOAIACORE Core",
+        version="0.1.0",
+        dependencies=[Depends(require_operator)],
+    )
     app.state.settings = active_settings
     app.state.database = database
     app.state.job_dispatcher = build_dispatcher(active_settings)
+
+    @app.middleware("http")
+    async def operator_audit_headers(request: Request, call_next):
+        response = await call_next(request)
+        operator = getattr(request.state, "operator", None)
+        if operator is not None:
+            response.headers["X-SOAIA-Audit-Operator"] = operator.operator_id
+            response.headers["X-SOAIA-Audit-Role"] = operator.role
+            response.headers["X-Correlation-ID"] = operator.correlation_id
+        return response
 
     @app.exception_handler(RuntimeContractError)
     async def runtime_error_handler(request: Request, exc: RuntimeContractError):

--- a/apps/core/tests/test_auth.py
+++ b/apps/core/tests/test_auth.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from pathlib import Path
+import hashlib
+
+from fastapi.testclient import TestClient
+import pytest
+
+from soaiacore_core.auth import OperatorAuthError, sign_operator_context, verify_operator_context
+from soaiacore_core.main import create_app
+from soaiacore_runtime.config import RuntimeSettings
+
+
+SECRET = "test-only-internal-auth-secret-32-bytes-minimum"
+OPERATOR_ID = "op_0123456789abcdef01234567"
+EMPTY_SHA256 = hashlib.sha256(b"").hexdigest()
+
+
+def protected_settings() -> RuntimeSettings:
+    return RuntimeSettings(
+        database_url="postgresql://unused/soaiacore",
+        provider_mode="MOCK",
+        repo_root=Path("."),
+        schema_dir=Path("schemas"),
+        migration_dir=Path("db/migrations"),
+        fixture_dir=Path("fixtures"),
+        storage_account_name=None,
+        storage_container_name=None,
+        internal_auth_required=True,
+        internal_auth_secret=SECRET,
+    )
+
+
+def signed_headers(*, role: str = "OPERATOR", now: int = 1_700_000_000) -> dict[str, str]:
+    correlation_id = "corr_security_test"
+    timestamp = str(now)
+    signature = sign_operator_context(
+        SECRET,
+        method="GET",
+        path="/v1/projects",
+        timestamp=timestamp,
+        correlation_id=correlation_id,
+        operator_id=OPERATOR_ID,
+        role=role,
+        content_sha256=EMPTY_SHA256,
+    )
+    return {
+        "X-Correlation-ID": correlation_id,
+        "X-SOAIA-Operator-ID": OPERATOR_ID,
+        "X-SOAIA-Operator-Role": role,
+        "X-SOAIA-Auth-Timestamp": timestamp,
+        "X-SOAIA-Auth-Signature": signature,
+        "X-SOAIA-Content-SHA256": EMPTY_SHA256,
+    }
+
+
+def test_core_rejects_unauthenticated_product_request_without_secret_leak():
+    with TestClient(create_app(protected_settings())) as client:
+        response = client.get("/v1/projects")
+
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "OPERATOR_AUTH_REQUIRED"
+    assert SECRET not in response.text
+
+
+def test_core_accepts_signed_operator_context_and_rejects_unknown_role():
+    headers = signed_headers()
+    context = verify_operator_context(
+        SECRET,
+        method="GET",
+        path="/v1/projects",
+        timestamp=headers["X-SOAIA-Auth-Timestamp"],
+        correlation_id=headers["X-Correlation-ID"],
+        operator_id=headers["X-SOAIA-Operator-ID"],
+        role=headers["X-SOAIA-Operator-Role"],
+        signature=headers["X-SOAIA-Auth-Signature"],
+        content_sha256=headers["X-SOAIA-Content-SHA256"],
+        actual_content_sha256=EMPTY_SHA256,
+        now=1_700_000_000,
+    )
+    assert context.operator_id == OPERATOR_ID
+    assert context.role == "OPERATOR"
+
+    invalid = signed_headers(role="READER")
+    with pytest.raises(OperatorAuthError, match="role is not allowed"):
+        verify_operator_context(
+            SECRET,
+            method="GET",
+            path="/v1/projects",
+            timestamp=invalid["X-SOAIA-Auth-Timestamp"],
+            correlation_id=invalid["X-Correlation-ID"],
+            operator_id=invalid["X-SOAIA-Operator-ID"],
+            role=invalid["X-SOAIA-Operator-Role"],
+            signature=invalid["X-SOAIA-Auth-Signature"],
+            content_sha256=invalid["X-SOAIA-Content-SHA256"],
+            actual_content_sha256=EMPTY_SHA256,
+            now=1_700_000_000,
+        )
+
+
+def test_core_rejects_expired_or_tampered_context():
+    headers = signed_headers(now=1_700_000_000)
+    with pytest.raises(OperatorAuthError) as expired:
+        verify_operator_context(
+            SECRET,
+            method="GET",
+            path="/v1/projects",
+            timestamp=headers["X-SOAIA-Auth-Timestamp"],
+            correlation_id=headers["X-Correlation-ID"],
+            operator_id=headers["X-SOAIA-Operator-ID"],
+            role=headers["X-SOAIA-Operator-Role"],
+            signature=headers["X-SOAIA-Auth-Signature"],
+            content_sha256=headers["X-SOAIA-Content-SHA256"],
+            actual_content_sha256=EMPTY_SHA256,
+            now=1_700_000_121,
+        )
+    assert expired.value.code == "OPERATOR_AUTH_EXPIRED"
+
+    with pytest.raises(OperatorAuthError) as tampered:
+        verify_operator_context(
+            SECRET,
+            method="GET",
+            path="/v1/projects/other",
+            timestamp=headers["X-SOAIA-Auth-Timestamp"],
+            correlation_id=headers["X-Correlation-ID"],
+            operator_id=headers["X-SOAIA-Operator-ID"],
+            role=headers["X-SOAIA-Operator-Role"],
+            signature=headers["X-SOAIA-Auth-Signature"],
+            content_sha256=headers["X-SOAIA-Content-SHA256"],
+            actual_content_sha256=EMPTY_SHA256,
+            now=1_700_000_000,
+        )
+    assert tampered.value.code == "OPERATOR_AUTH_INVALID"

--- a/apps/core/tests/test_run_dispatch.py
+++ b/apps/core/tests/test_run_dispatch.py
@@ -51,6 +51,7 @@ def test_run_dispatch_happens_after_database_commit(monkeypatch):
         fixture_dir=Path("fixtures"),
         storage_account_name=None,
         storage_container_name=None,
+        internal_auth_required=False,
     )
     app = core_main.create_app(settings)
     app.state.job_dispatcher = Dispatcher()

--- a/apps/web/src/app/api/auth/callback/route.js
+++ b/apps/web/src/app/api/auth/callback/route.js
@@ -1,0 +1,11 @@
+import { authErrorResponse, completeOidcLogin } from "../../../../server/auth.mjs";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request) {
+  try {
+    return await completeOidcLogin(request);
+  } catch (error) {
+    return authErrorResponse(error);
+  }
+}

--- a/apps/web/src/app/api/auth/login/route.js
+++ b/apps/web/src/app/api/auth/login/route.js
@@ -1,0 +1,11 @@
+import { authErrorResponse, beginOidcLogin } from "../../../../server/auth.mjs";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request) {
+  try {
+    return await beginOidcLogin(request);
+  } catch (error) {
+    return authErrorResponse(error);
+  }
+}

--- a/apps/web/src/app/api/auth/logout/route.js
+++ b/apps/web/src/app/api/auth/logout/route.js
@@ -1,0 +1,7 @@
+import { logout } from "../../../../server/auth.mjs";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request) {
+  return logout(request);
+}

--- a/apps/web/src/app/api/auth/session/route.js
+++ b/apps/web/src/app/api/auth/session/route.js
@@ -1,0 +1,13 @@
+import { authErrorResponse, requireSession, safeSession } from "../../../../server/auth.mjs";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request) {
+  try {
+    return Response.json(safeSession(requireSession(request)), {
+      headers: { "Cache-Control": "no-store" },
+    });
+  } catch (error) {
+    return authErrorResponse(error);
+  }
+}

--- a/apps/web/src/app/api/operator/context-inspector/[capsuleId]/route.js
+++ b/apps/web/src/app/api/operator/context-inspector/[capsuleId]/route.js
@@ -2,16 +2,19 @@ import {
   loadContextInspector,
   publicContextInspectorError,
 } from "../../../../../server/context-inspector.mjs";
+import { authenticatedApi } from "../../../../../server/auth-next.js";
 
 export const dynamic = "force-dynamic";
 
-export async function GET(_request, { params }) {
-  try {
-    const { capsuleId } = await params;
-    const data = await loadContextInspector(capsuleId);
-    return Response.json(data, { headers: { "Cache-Control": "no-store" } });
-  } catch (error) {
-    const failure = publicContextInspectorError(error);
-    return Response.json({ error: failure.error }, { status: failure.status });
-  }
+export async function GET(request, { params }) {
+  return authenticatedApi(request, async () => {
+    try {
+      const { capsuleId } = await params;
+      const data = await loadContextInspector(capsuleId);
+      return Response.json(data, { headers: { "Cache-Control": "no-store" } });
+    } catch (error) {
+      const failure = publicContextInspectorError(error);
+      return Response.json({ error: failure.error }, { status: failure.status });
+    }
+  });
 }

--- a/apps/web/src/app/api/operator/evidence/[evidenceRefId]/route.js
+++ b/apps/web/src/app/api/operator/evidence/[evidenceRefId]/route.js
@@ -2,17 +2,20 @@ import {
   loadEvidenceExplorer,
   publicEvidenceExplorerError,
 } from "../../../../../server/evidence-explorer.mjs";
+import { authenticatedApi } from "../../../../../server/auth-next.js";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(request, { params }) {
-  try {
-    const { evidenceRefId } = await params;
-    const claimId = new URL(request.url).searchParams.get("claim_id") ?? "";
-    const data = await loadEvidenceExplorer(evidenceRefId, { claimId });
-    return Response.json(data, { headers: { "Cache-Control": "no-store" } });
-  } catch (error) {
-    const failure = publicEvidenceExplorerError(error);
-    return Response.json({ error: failure.error }, { status: failure.status });
-  }
+  return authenticatedApi(request, async () => {
+    try {
+      const { evidenceRefId } = await params;
+      const claimId = new URL(request.url).searchParams.get("claim_id") ?? "";
+      const data = await loadEvidenceExplorer(evidenceRefId, { claimId });
+      return Response.json(data, { headers: { "Cache-Control": "no-store" } });
+    } catch (error) {
+      const failure = publicEvidenceExplorerError(error);
+      return Response.json({ error: failure.error }, { status: failure.status });
+    }
+  });
 }

--- a/apps/web/src/app/api/operator/runs/route.js
+++ b/apps/web/src/app/api/operator/runs/route.js
@@ -1,19 +1,22 @@
 import { loadRunsHistory, publicRunsHistoryError } from "../../../../server/runs-history.mjs";
+import { authenticatedApi } from "../../../../server/auth-next.js";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(request) {
-  const url = new URL(request.url);
-  try {
-    const data = await loadRunsHistory({
-      status: url.searchParams.get("status") ?? "",
-      projectId: url.searchParams.get("project_id") ?? "",
-      profileId: url.searchParams.get("profile_id") ?? "",
-      limit: url.searchParams.get("limit") ?? "25",
-    });
-    return Response.json(data, { headers: { "Cache-Control": "no-store" } });
-  } catch (error) {
-    const failure = publicRunsHistoryError(error);
-    return Response.json({ error: failure.error }, { status: failure.status });
-  }
+  return authenticatedApi(request, async () => {
+    const url = new URL(request.url);
+    try {
+      const data = await loadRunsHistory({
+        status: url.searchParams.get("status") ?? "",
+        projectId: url.searchParams.get("project_id") ?? "",
+        profileId: url.searchParams.get("profile_id") ?? "",
+        limit: url.searchParams.get("limit") ?? "25",
+      });
+      return Response.json(data, { headers: { "Cache-Control": "no-store" } });
+    } catch (error) {
+      const failure = publicRunsHistoryError(error);
+      return Response.json({ error: failure.error }, { status: failure.status });
+    }
+  });
 }

--- a/apps/web/src/app/api/operator/workflow/route.js
+++ b/apps/web/src/app/api/operator/workflow/route.js
@@ -3,6 +3,7 @@ import {
   performOperatorAction,
   publicOperatorError,
 } from "../../../../server/operator-workflow.mjs";
+import { authenticatedApi } from "../../../../server/auth-next.js";
 
 export const dynamic = "force-dynamic";
 
@@ -12,35 +13,39 @@ function errorResponse(error) {
 }
 
 export async function GET(request) {
-  const url = new URL(request.url);
-  try {
-    const snapshot = await loadOperatorWorkflow({
-      projectId: url.searchParams.get("project_id"),
-      corpusId: url.searchParams.get("corpus_id"),
-      contextId: url.searchParams.get("context_id"),
-      capsuleId: url.searchParams.get("context_capsule_id"),
-    });
-    return Response.json(snapshot, { headers: { "Cache-Control": "no-store" } });
-  } catch (error) {
-    return errorResponse(error);
-  }
+  return authenticatedApi(request, async () => {
+    const url = new URL(request.url);
+    try {
+      const snapshot = await loadOperatorWorkflow({
+        projectId: url.searchParams.get("project_id"),
+        corpusId: url.searchParams.get("corpus_id"),
+        contextId: url.searchParams.get("context_id"),
+        capsuleId: url.searchParams.get("context_capsule_id"),
+      });
+      return Response.json(snapshot, { headers: { "Cache-Control": "no-store" } });
+    } catch (error) {
+      return errorResponse(error);
+    }
+  });
 }
 
 export async function POST(request) {
-  let input;
-  try {
-    input = await request.json();
-  } catch {
-    return Response.json(
-      { error: { code: "OPERATOR_JSON_INVALID", message: "The request body is invalid." } },
-      { status: 400 },
-    );
-  }
-  try {
-    return Response.json(await performOperatorAction(input), {
-      headers: { "Cache-Control": "no-store" },
-    });
-  } catch (error) {
-    return errorResponse(error);
-  }
+  return authenticatedApi(request, async () => {
+    let input;
+    try {
+      input = await request.json();
+    } catch {
+      return Response.json(
+        { error: { code: "OPERATOR_JSON_INVALID", message: "The request body is invalid." } },
+        { status: 400 },
+      );
+    }
+    try {
+      return Response.json(await performOperatorAction(input), {
+        headers: { "Cache-Control": "no-store" },
+      });
+    } catch (error) {
+      return errorResponse(error);
+    }
+  });
 }

--- a/apps/web/src/app/api/runs/[runId]/route.js
+++ b/apps/web/src/app/api/runs/[runId]/route.js
@@ -1,27 +1,30 @@
 import { NextResponse } from "next/server";
 import { coreRequest } from "../../../../server/core-client.mjs";
+import { authenticatedApi } from "../../../../server/auth-next.js";
 
 export const dynamic = "force-dynamic";
 
-export async function GET(_request, { params }) {
-  const { runId } = await params;
-  try {
-    const run = await coreRequest(`/v1/runs/${encodeURIComponent(runId)}`);
-    return NextResponse.json(run, {
-      headers: { "Cache-Control": "no-store" },
-    });
-  } catch {
-    return NextResponse.json(
-      {
-        error: {
-          code: "RUN_STATUS_UNAVAILABLE",
-          message: "The Core service is temporarily unavailable.",
-          stage: "RUN_STATUS",
-          retryable: true,
-          correlation_id: null,
+export async function GET(request, { params }) {
+  return authenticatedApi(request, async () => {
+    const { runId } = await params;
+    try {
+      const run = await coreRequest(`/v1/runs/${encodeURIComponent(runId)}`);
+      return NextResponse.json(run, {
+        headers: { "Cache-Control": "no-store" },
+      });
+    } catch {
+      return NextResponse.json(
+        {
+          error: {
+            code: "RUN_STATUS_UNAVAILABLE",
+            message: "The Core service is temporarily unavailable.",
+            stage: "RUN_STATUS",
+            retryable: true,
+            correlation_id: null,
+          },
         },
-      },
-      { status: 502, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+        { status: 502, headers: { "Cache-Control": "no-store" } },
+      );
+    }
+  });
 }

--- a/apps/web/src/app/context-inspector/[capsuleId]/page.js
+++ b/apps/web/src/app/context-inspector/[capsuleId]/page.js
@@ -1,6 +1,8 @@
 import ContextInspectorClient from "./context-inspector-client";
+import { requirePageSession } from "../../../server/auth-next.js";
 
 export default async function ContextInspectorPage({ params }) {
   const { capsuleId } = await params;
+  await requirePageSession(`/context-inspector/${encodeURIComponent(capsuleId)}`);
   return <ContextInspectorClient capsuleId={capsuleId} />;
 }

--- a/apps/web/src/app/evidence-explorer/[evidenceRefId]/page.js
+++ b/apps/web/src/app/evidence-explorer/[evidenceRefId]/page.js
@@ -1,7 +1,9 @@
 import EvidenceExplorerClient from "./evidence-explorer-client";
+import { requirePageSession } from "../../../server/auth-next.js";
 
 export default async function EvidenceExplorerPage({ params, searchParams }) {
   const { evidenceRefId } = await params;
   const query = await searchParams;
+  await requirePageSession(`/evidence-explorer/${encodeURIComponent(evidenceRefId)}`);
   return <EvidenceExplorerClient evidenceRefId={evidenceRefId} claimId={query?.claim_id ?? ""} />;
 }

--- a/apps/web/src/app/forbidden/page.js
+++ b/apps/web/src/app/forbidden/page.js
@@ -1,0 +1,12 @@
+export default function ForbiddenPage() {
+  return (
+    <section className="auth-page">
+      <p className="eyebrow">Access denied</p>
+      <h1>Your operator role does not permit this action.</h1>
+      <p>Contact the pilot administrator if your assigned role is incorrect.</p>
+      <form action="/api/auth/logout" method="post">
+        <button className="button" type="submit">Sign out</button>
+      </form>
+    </section>
+  );
+}

--- a/apps/web/src/app/layout.js
+++ b/apps/web/src/app/layout.js
@@ -1,4 +1,6 @@
 import Link from "next/link";
+import { cookies } from "next/headers";
+import { SESSION_COOKIE, sessionById } from "../server/auth.mjs";
 import "./styles.css";
 
 export const metadata = {
@@ -6,7 +8,9 @@ export const metadata = {
   description: "Synthetic-only SOAIACORE P0 runtime pilot",
 };
 
-export default function RootLayout({ children }) {
+export default async function RootLayout({ children }) {
+  const cookieStore = await cookies();
+  const session = sessionById(cookieStore.get(SESSION_COOKIE)?.value);
   return (
     <html lang="en">
       <body>
@@ -18,6 +22,14 @@ export default function RootLayout({ children }) {
               <Link href="/workflow">Operator workflow</Link>
               <Link href="/runs">Runs history</Link>
             </nav>
+            {session ? (
+              <div className="operator-session">
+                <span>{session.role} · {session.operatorId}</span>
+                <form action="/api/auth/logout" method="post">
+                  <button type="submit" className="text-button">Sign out</button>
+                </form>
+              </div>
+            ) : null}
             <span className="environment-badge">MOCK · SYNTHETIC DATA ONLY</span>
           </div>
         </header>

--- a/apps/web/src/app/login/page.js
+++ b/apps/web/src/app/login/page.js
@@ -1,0 +1,24 @@
+import Link from "next/link";
+
+import { safeReturnTo } from "../../server/auth.mjs";
+
+export default async function LoginPage({ searchParams }) {
+  const query = await searchParams;
+  const returnTo = safeReturnTo(query?.return_to);
+  return (
+    <section className="auth-page">
+      <p className="eyebrow">Controlled pilot access</p>
+      <h1>Sign in as an authorized operator</h1>
+      <p>
+        SOAIACORE uses the approved organization identity provider. Anonymous access and
+        self-service registration are disabled.
+      </p>
+      <Link
+        className="button primary-action"
+        href={`/api/auth/login?return_to=${encodeURIComponent(returnTo)}`}
+      >
+        Continue with organization sign-in
+      </Link>
+    </section>
+  );
+}

--- a/apps/web/src/app/page.js
+++ b/apps/web/src/app/page.js
@@ -1,6 +1,8 @@
 import Link from "next/link";
+import { requirePageSession } from "../server/auth-next.js";
 
-export default function HomePage() {
+export default async function HomePage() {
+  await requirePageSession("/");
   return (
     <section className="portal-home">
       <div className="portal-hero">

--- a/apps/web/src/app/receipts/[runId]/page.js
+++ b/apps/web/src/app/receipts/[runId]/page.js
@@ -1,11 +1,17 @@
 import { coreRequest } from "../../../server/core-client.mjs";
 import Link from "next/link";
+import { requirePageSession } from "../../../server/auth-next.js";
+import { withOperatorContext } from "../../../server/operator-context.mjs";
 
 export const dynamic = "force-dynamic";
 
 export default async function ReceiptPage({ params }) {
   const { runId } = await params;
-  const receipt = await coreRequest(`/v1/runs/${encodeURIComponent(runId)}/receipt`);
+  const returnTo = `/receipts/${encodeURIComponent(runId)}`;
+  const session = await requirePageSession(returnTo);
+  const receipt = await withOperatorContext(session, () =>
+    coreRequest(`/v1/runs/${encodeURIComponent(runId)}/receipt`),
+  );
   return (
     <section className="receipt-page">
       <p className="eyebrow">ContextReceipt</p>

--- a/apps/web/src/app/runs/[runId]/page.js
+++ b/apps/web/src/app/runs/[runId]/page.js
@@ -1,10 +1,16 @@
 import { coreRequest } from "../../../server/core-client.mjs";
+import { requirePageSession } from "../../../server/auth-next.js";
+import { withOperatorContext } from "../../../server/operator-context.mjs";
 import RunStatusClient from "./run-status-client";
 
 export const dynamic = "force-dynamic";
 
 export default async function RunPage({ params }) {
   const { runId } = await params;
-  const run = await coreRequest(`/v1/runs/${encodeURIComponent(runId)}`);
+  const returnTo = `/runs/${encodeURIComponent(runId)}`;
+  const session = await requirePageSession(returnTo);
+  const run = await withOperatorContext(session, () =>
+    coreRequest(`/v1/runs/${encodeURIComponent(runId)}`),
+  );
   return <RunStatusClient runId={runId} initialRun={run} />;
 }

--- a/apps/web/src/app/runs/new/page.js
+++ b/apps/web/src/app/runs/new/page.js
@@ -1,6 +1,8 @@
 import Link from "next/link";
+import { requirePageSession } from "../../../server/auth-next.js";
 
-export default function NewRunPage() {
+export default async function NewRunPage() {
+  await requirePageSession("/runs/new");
   return (
     <section className="empty-state-page">
       <p className="eyebrow">Operator workflow</p>

--- a/apps/web/src/app/runs/page.js
+++ b/apps/web/src/app/runs/page.js
@@ -1,5 +1,7 @@
 import RunsHistoryClient from "./runs-history-client";
+import { requirePageSession } from "../../server/auth-next.js";
 
-export default function RunsHistoryPage() {
+export default async function RunsHistoryPage() {
+  await requirePageSession("/runs");
   return <RunsHistoryClient />;
 }

--- a/apps/web/src/app/styles.css
+++ b/apps/web/src/app/styles.css
@@ -211,6 +211,13 @@ pre { background: #101d30; border-radius: .5rem; overflow: auto; padding: 1rem; 
 .history-card-heading h2 { font-size: 1.1rem; margin: .35rem 0 0; overflow-wrap: anywhere; }
 .history-state { color: #8fa3bf; font-size: .72rem; letter-spacing: .08em; text-transform: uppercase; }
 .history-card dl { grid-template-columns: 8rem 1fr; margin: 1rem 0 0; }
+.operator-session { align-items: center; display: flex; gap: .65rem; }
+.operator-session span { color: #8fa3bf; font-size: .72rem; }
+.operator-session form { margin: 0; }
+.text-button { background: transparent; border: 0; color: #75d7ff; cursor: pointer; padding: 0; text-decoration: underline; }
+.auth-page { background: #0d1929; border: 1px solid #24334a; border-radius: .9rem; display: grid; gap: 1rem; max-width: 680px; padding: 2rem; }
+.auth-page h1, .auth-page p { margin: 0; }
+.auth-page .button, .auth-page form { justify-self: start; }
 
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after { scroll-behavior: auto !important; transition-duration: .01ms !important; animation-duration: .01ms !important; }

--- a/apps/web/src/app/workflow/page.js
+++ b/apps/web/src/app/workflow/page.js
@@ -1,10 +1,13 @@
 import OperatorWorkflow from "./workflow-client";
 import { loadOperatorWorkflow } from "../../server/operator-workflow.mjs";
+import { requirePageSession } from "../../server/auth-next.js";
+import { withOperatorContext } from "../../server/operator-context.mjs";
 
 export const dynamic = "force-dynamic";
 
 export default async function OperatorWorkflowPage() {
-  const initialData = await loadOperatorWorkflow();
+  const session = await requirePageSession("/workflow");
+  const initialData = await withOperatorContext(session, () => loadOperatorWorkflow());
   return (
     <section className="workflow-shell">
       <div className="workflow-hero">

--- a/apps/web/src/server/auth-next.js
+++ b/apps/web/src/server/auth-next.js
@@ -1,0 +1,33 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+import {
+  AuthError,
+  SESSION_COOKIE,
+  authErrorResponse,
+  requireRole,
+  requireSession,
+  sessionById,
+} from "./auth.mjs";
+import { withOperatorContext } from "./operator-context.mjs";
+
+export async function requirePageSession(returnTo = "/", requiredRole = "OPERATOR") {
+  const store = await cookies();
+  const session = sessionById(store.get(SESSION_COOKIE)?.value);
+  if (!session) redirect(`/login?return_to=${encodeURIComponent(returnTo)}`);
+  try {
+    return requireRole(session, requiredRole);
+  } catch (error) {
+    if (error instanceof AuthError) redirect("/forbidden");
+    throw error;
+  }
+}
+
+export async function authenticatedApi(request, callback, requiredRole = "OPERATOR") {
+  try {
+    const session = requireSession(request, requiredRole);
+    return await withOperatorContext(session, () => callback(session));
+  } catch (error) {
+    return authErrorResponse(error);
+  }
+}

--- a/apps/web/src/server/auth.mjs
+++ b/apps/web/src/server/auth.mjs
@@ -1,0 +1,366 @@
+import {
+  createHash,
+  createPublicKey,
+  randomBytes,
+  timingSafeEqual,
+  verify as verifySignature,
+} from "node:crypto";
+
+export const SESSION_COOKIE = "__Host-soaiacore_session";
+export const OIDC_STATE_COOKIE = "__Host-soaiacore_oidc_state";
+
+const VALID_ROLES = new Set(["OPERATOR", "ADMIN"]);
+const MAX_PENDING_STATES = 1_000;
+const MAX_SESSIONS = 10_000;
+const stateKey = Symbol.for("soaiacore.oidc.states");
+const sessionKey = Symbol.for("soaiacore.operator.sessions");
+const discoveryKey = Symbol.for("soaiacore.oidc.discovery");
+const states = globalThis[stateKey] ?? new Map();
+const sessions = globalThis[sessionKey] ?? new Map();
+const discoveryCache = globalThis[discoveryKey] ?? new Map();
+globalThis[stateKey] = states;
+globalThis[sessionKey] = sessions;
+globalThis[discoveryKey] = discoveryCache;
+
+export class AuthError extends Error {
+  constructor(code, message, status = 401) {
+    super(message);
+    this.name = "AuthError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+function base64url(value) {
+  return Buffer.from(value).toString("base64url");
+}
+
+function normalizeIssuer(value) {
+  return value.replace(/\/$/, "");
+}
+
+function positiveInteger(value, fallback) {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function authConfig(environment = process.env) {
+  const issuer = environment.SOAIACORE_OIDC_ISSUER?.trim();
+  const clientId = environment.SOAIACORE_OIDC_CLIENT_ID?.trim();
+  const clientSecret = environment.SOAIACORE_OIDC_CLIENT_SECRET?.trim();
+  const webBaseUrl = environment.SOAIACORE_WEB_BASE_URL?.trim();
+  if (!issuer || !clientId || !clientSecret || !webBaseUrl) {
+    throw new AuthError(
+      "AUTH_NOT_CONFIGURED",
+      "Operator authentication is not configured.",
+      503,
+    );
+  }
+  const issuerUrl = new URL(issuer);
+  const baseUrl = new URL(webBaseUrl);
+  if (issuerUrl.protocol !== "https:" || baseUrl.protocol !== "https:") {
+    throw new AuthError("AUTH_CONFIGURATION_INVALID", "OIDC URLs must use HTTPS.", 503);
+  }
+  return {
+    issuer: normalizeIssuer(issuerUrl.toString()),
+    clientId,
+    clientSecret,
+    webBaseUrl: normalizeIssuer(baseUrl.toString()),
+    redirectUri: `${normalizeIssuer(baseUrl.toString())}/api/auth/callback`,
+    operatorGroup: environment.SOAIACORE_OIDC_OPERATOR_GROUP?.trim() || "SOAIACORE_OPERATOR",
+    adminGroup: environment.SOAIACORE_OIDC_ADMIN_GROUP?.trim() || "SOAIACORE_ADMIN",
+    sessionTtlSeconds: positiveInteger(environment.SOAIACORE_SESSION_TTL_SECONDS, 28_800),
+    secureCookies: true,
+  };
+}
+
+export function safeReturnTo(value, fallback = "/") {
+  if (typeof value !== "string" || !value.startsWith("/") || value.startsWith("//")) {
+    return fallback;
+  }
+  try {
+    const parsed = new URL(value, "https://return.invalid");
+    if (parsed.origin !== "https://return.invalid") return fallback;
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return fallback;
+  }
+}
+
+function cookie(name, value, { maxAge, secure = true } = {}) {
+  const parts = [
+    `${name}=${encodeURIComponent(value)}`,
+    "Path=/",
+    "HttpOnly",
+    "SameSite=Lax",
+    `Max-Age=${Math.max(0, Math.floor(maxAge ?? 0))}`,
+  ];
+  if (secure) parts.push("Secure");
+  return parts.join("; ");
+}
+
+function cookieValue(header, name) {
+  for (const item of (header ?? "").split(";")) {
+    const [key, ...rest] = item.trim().split("=");
+    if (key === name) return decodeURIComponent(rest.join("="));
+  }
+  return null;
+}
+
+function prune(nowSeconds) {
+  for (const [id, state] of states) if (state.expiresAt <= nowSeconds) states.delete(id);
+  for (const [id, session] of sessions) if (session.expiresAt <= nowSeconds) sessions.delete(id);
+}
+
+async function discovery(config, fetchImpl) {
+  const cached = discoveryCache.get(config.issuer);
+  if (cached) return cached;
+  const response = await fetchImpl(`${config.issuer}/.well-known/openid-configuration`, {
+    headers: { Accept: "application/json" },
+    cache: "no-store",
+  });
+  if (!response.ok) throw new AuthError("OIDC_DISCOVERY_FAILED", "Identity provider is unavailable.", 503);
+  const metadata = await response.json();
+  if (
+    normalizeIssuer(metadata.issuer ?? "") !== config.issuer ||
+    !metadata.authorization_endpoint?.startsWith("https://") ||
+    !metadata.token_endpoint?.startsWith("https://") ||
+    !metadata.jwks_uri?.startsWith("https://")
+  ) {
+    throw new AuthError("OIDC_DISCOVERY_INVALID", "Identity provider metadata is invalid.", 503);
+  }
+  discoveryCache.set(config.issuer, metadata);
+  return metadata;
+}
+
+function claimValues(claims) {
+  const values = [];
+  for (const key of ["roles", "groups"]) {
+    const value = claims[key];
+    if (Array.isArray(value)) values.push(...value);
+    else if (typeof value === "string") values.push(value);
+  }
+  return new Set(values.map((value) => String(value).toUpperCase()));
+}
+
+export function roleFromClaims(claims, config) {
+  const values = claimValues(claims);
+  if (values.has("ADMIN") || values.has(config.adminGroup.toUpperCase())) return "ADMIN";
+  if (values.has("OPERATOR") || values.has(config.operatorGroup.toUpperCase())) return "OPERATOR";
+  throw new AuthError("OPERATOR_ROLE_FORBIDDEN", "This identity is not authorized for the pilot.", 403);
+}
+
+export function createSessionFromClaims(claims, config, nowSeconds = Math.floor(Date.now() / 1000)) {
+  if (!claims.sub || !claims.iss) throw new AuthError("OIDC_IDENTITY_INVALID", "Identity claims are invalid.");
+  const role = roleFromClaims(claims, config);
+  const operatorId = `op_${createHash("sha256")
+    .update(`${claims.iss}\u0000${claims.sub}`)
+    .digest("hex")
+    .slice(0, 24)}`;
+  const id = base64url(randomBytes(32));
+  const expiresAt = Math.min(
+    nowSeconds + config.sessionTtlSeconds,
+    Number.isFinite(claims.exp) ? claims.exp : Number.MAX_SAFE_INTEGER,
+  );
+  const session = Object.freeze({ id, operatorId, role, issuedAt: nowSeconds, expiresAt });
+  prune(nowSeconds);
+  if (sessions.size >= MAX_SESSIONS) {
+    throw new AuthError("SESSION_CAPACITY_REACHED", "Operator session capacity is temporarily unavailable.", 503);
+  }
+  sessions.set(id, session);
+  return session;
+}
+
+export function sessionById(id, nowSeconds = Math.floor(Date.now() / 1000)) {
+  prune(nowSeconds);
+  if (!id) return null;
+  return sessions.get(id) ?? null;
+}
+
+export function sessionFromRequest(request, nowSeconds = Math.floor(Date.now() / 1000)) {
+  return sessionById(cookieValue(request.headers.get("cookie"), SESSION_COOKIE), nowSeconds);
+}
+
+export function requireSession(request, requiredRole = "OPERATOR") {
+  const session = sessionFromRequest(request);
+  if (!session) throw new AuthError("AUTHENTICATION_REQUIRED", "Sign in is required.", 401);
+  requireRole(session, requiredRole);
+  return session;
+}
+
+export function requireRole(session, requiredRole) {
+  if (!VALID_ROLES.has(requiredRole)) throw new TypeError("Unknown operator role");
+  if (requiredRole === "ADMIN" && session.role !== "ADMIN") {
+    throw new AuthError("ADMIN_ROLE_REQUIRED", "Administrator access is required.", 403);
+  }
+  return session;
+}
+
+export function safeSession(session) {
+  return { operator_id: session.operatorId, role: session.role, expires_at: session.expiresAt };
+}
+
+export async function beginOidcLogin(request, { environment = process.env, fetchImpl = fetch } = {}) {
+  const config = authConfig(environment);
+  const metadata = await discovery(config, fetchImpl);
+  const now = Math.floor(Date.now() / 1000);
+  prune(now);
+  if (states.size >= MAX_PENDING_STATES) {
+    throw new AuthError("OIDC_CAPACITY_REACHED", "Sign-in capacity is temporarily unavailable.", 503);
+  }
+  const state = base64url(randomBytes(24));
+  const nonce = base64url(randomBytes(24));
+  const verifier = base64url(randomBytes(32));
+  const challenge = base64url(createHash("sha256").update(verifier).digest());
+  const returnTo = safeReturnTo(new URL(request.url).searchParams.get("return_to"));
+  states.set(state, { nonce, verifier, returnTo, expiresAt: now + 600 });
+  const authorization = new URL(metadata.authorization_endpoint);
+  authorization.search = new URLSearchParams({
+    response_type: "code",
+    client_id: config.clientId,
+    redirect_uri: config.redirectUri,
+    scope: "openid profile",
+    state,
+    nonce,
+    code_challenge: challenge,
+    code_challenge_method: "S256",
+  }).toString();
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: authorization.toString(),
+      "Set-Cookie": cookie(OIDC_STATE_COOKIE, state, { maxAge: 600, secure: config.secureCookies }),
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+function parseJwt(token) {
+  const parts = token.split(".");
+  if (parts.length !== 3) throw new AuthError("OIDC_ID_TOKEN_INVALID", "Identity token is invalid.");
+  try {
+    return {
+      header: JSON.parse(Buffer.from(parts[0], "base64url").toString("utf8")),
+      claims: JSON.parse(Buffer.from(parts[1], "base64url").toString("utf8")),
+      signed: Buffer.from(`${parts[0]}.${parts[1]}`),
+      signature: Buffer.from(parts[2], "base64url"),
+    };
+  } catch {
+    throw new AuthError("OIDC_ID_TOKEN_INVALID", "Identity token is invalid.");
+  }
+}
+
+async function validateIdToken(token, metadata, config, expectedNonce, fetchImpl) {
+  const parsed = parseJwt(token);
+  if (parsed.header.alg !== "RS256" || typeof parsed.header.kid !== "string") {
+    throw new AuthError("OIDC_ID_TOKEN_INVALID", "Identity token algorithm is not allowed.");
+  }
+  const response = await fetchImpl(metadata.jwks_uri, { headers: { Accept: "application/json" }, cache: "no-store" });
+  if (!response.ok) throw new AuthError("OIDC_KEYS_UNAVAILABLE", "Identity verification keys are unavailable.", 503);
+  const jwks = await response.json();
+  const jwk = jwks.keys?.find((candidate) => candidate.kid === parsed.header.kid && candidate.kty === "RSA");
+  if (!jwk) throw new AuthError("OIDC_ID_TOKEN_INVALID", "Identity token key is invalid.");
+  const valid = verifySignature("RSA-SHA256", parsed.signed, createPublicKey({ key: jwk, format: "jwk" }), parsed.signature);
+  if (!valid) throw new AuthError("OIDC_ID_TOKEN_INVALID", "Identity token signature is invalid.");
+  const now = Math.floor(Date.now() / 1000);
+  const audience = Array.isArray(parsed.claims.aud) ? parsed.claims.aud : [parsed.claims.aud];
+  const multipleAudiencesWithoutAuthorizedParty =
+    audience.length > 1 && parsed.claims.azp !== config.clientId;
+  if (
+    normalizeIssuer(parsed.claims.iss ?? "") !== config.issuer ||
+    !audience.includes(config.clientId) ||
+    !Number.isFinite(parsed.claims.exp) ||
+    parsed.claims.exp <= now ||
+    (Number.isFinite(parsed.claims.nbf) && parsed.claims.nbf > now + 60) ||
+    (Number.isFinite(parsed.claims.iat) && parsed.claims.iat > now + 60) ||
+    multipleAudiencesWithoutAuthorizedParty ||
+    parsed.claims.nonce !== expectedNonce
+  ) {
+    throw new AuthError("OIDC_ID_TOKEN_INVALID", "Identity token claims are invalid.");
+  }
+  return parsed.claims;
+}
+
+export async function completeOidcLogin(request, { environment = process.env, fetchImpl = fetch } = {}) {
+  const config = authConfig(environment);
+  const metadata = await discovery(config, fetchImpl);
+  const url = new URL(request.url);
+  const state = url.searchParams.get("state");
+  const code = url.searchParams.get("code");
+  const stateCookie = cookieValue(request.headers.get("cookie"), OIDC_STATE_COOKIE);
+  const comparable = state && stateCookie && state.length === stateCookie.length;
+  if (!comparable || !timingSafeEqual(Buffer.from(state), Buffer.from(stateCookie))) {
+    throw new AuthError("OIDC_STATE_INVALID", "OIDC transaction is invalid.");
+  }
+  const transaction = states.get(state);
+  states.delete(state);
+  const now = Math.floor(Date.now() / 1000);
+  if (!code || !transaction || transaction.expiresAt <= now) {
+    throw new AuthError("OIDC_TRANSACTION_EXPIRED", "OIDC transaction has expired.");
+  }
+  const tokenResponse = await fetchImpl(metadata.token_endpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: config.redirectUri,
+      client_id: config.clientId,
+      client_secret: config.clientSecret,
+      code_verifier: transaction.verifier,
+    }),
+    cache: "no-store",
+  });
+  if (!tokenResponse.ok) throw new AuthError("OIDC_TOKEN_EXCHANGE_FAILED", "Identity provider rejected the login.");
+  const tokens = await tokenResponse.json();
+  if (typeof tokens.id_token !== "string") throw new AuthError("OIDC_ID_TOKEN_MISSING", "Identity provider response is incomplete.");
+  const claims = await validateIdToken(tokens.id_token, metadata, config, transaction.nonce, fetchImpl);
+  const session = createSessionFromClaims(claims, config, now);
+  return new Response(null, {
+    status: 302,
+    headers: [
+      ["Location", `${config.webBaseUrl}${transaction.returnTo}`],
+      ["Set-Cookie", cookie(SESSION_COOKIE, session.id, { maxAge: session.expiresAt - now, secure: config.secureCookies })],
+      ["Set-Cookie", cookie(OIDC_STATE_COOKIE, "", { maxAge: 0, secure: config.secureCookies })],
+      ["Cache-Control", "no-store"],
+    ],
+  });
+}
+
+export function logout(request, { environment = process.env } = {}) {
+  let secure = true;
+  let baseUrl = new URL(request.url).origin;
+  try {
+    const config = authConfig(environment);
+    secure = config.secureCookies;
+    baseUrl = config.webBaseUrl;
+  } catch {
+    // Logout remains available during a configuration incident.
+  }
+  const id = cookieValue(request.headers.get("cookie"), SESSION_COOKIE);
+  if (id) sessions.delete(id);
+  return new Response(null, {
+    status: 303,
+    headers: {
+      Location: `${baseUrl}/login`,
+      "Set-Cookie": cookie(SESSION_COOKIE, "", { maxAge: 0, secure }),
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+export function authErrorResponse(error) {
+  const failure = error instanceof AuthError
+    ? error
+    : new AuthError("AUTHENTICATION_FAILED", "Authentication could not be completed.", 500);
+  return Response.json(
+    { error: { code: failure.code, message: failure.message } },
+    { status: failure.status, headers: { "Cache-Control": "no-store" } },
+  );
+}
+
+export function resetAuthStateForTests() {
+  states.clear();
+  sessions.clear();
+  discoveryCache.clear();
+}

--- a/apps/web/src/server/core-client.mjs
+++ b/apps/web/src/server/core-client.mjs
@@ -1,3 +1,7 @@
+import { createHash, createHmac, randomUUID } from "node:crypto";
+
+import { currentOperatorContext } from "./operator-context.mjs";
+
 export class CoreApiError extends Error {
   constructor(code, message, status, details = {}) {
     super(message);
@@ -37,22 +41,57 @@ export async function coreRequest(
     includeResponseMetadata = false,
     fetchImpl = globalThis.fetch,
     environment = process.env,
+    operatorContext,
   } = {},
 ) {
   if (!path.startsWith("/v1/") && !path.startsWith("/health/")) {
     throw new CoreApiError("CORE_PATH_REJECTED", "Core path is not allowed.", 400);
   }
   const headers = { Accept: "application/json" };
+  const bodyText = body === undefined ? undefined : JSON.stringify(body);
   if (body !== undefined) {
     headers["Content-Type"] = "application/json";
   }
   if (idempotencyKey) {
     headers["Idempotency-Key"] = idempotencyKey;
   }
+  if (path.startsWith("/v1/")) {
+    const operator = operatorContext ?? currentOperatorContext();
+    const secret = environment.SOAIACORE_INTERNAL_AUTH_SECRET;
+    if (!operator || !secret || Buffer.byteLength(secret, "utf8") < 32) {
+      throw new CoreApiError(
+        "CORE_AUTH_NOT_CONFIGURED",
+        "The Core authorization boundary is unavailable.",
+        503,
+      );
+    }
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const correlationId = `corr_${randomUUID().replaceAll("-", "")}`;
+    const parsedPath = new URL(path, "https://core.internal");
+    const canonicalPath = `${parsedPath.pathname}${parsedPath.search}`;
+    const contentSha256 = createHash("sha256").update(bodyText ?? "").digest("hex");
+    const signaturePayload = [
+      method.toUpperCase(),
+      canonicalPath,
+      timestamp,
+      correlationId,
+      operator.operatorId,
+      operator.role,
+      contentSha256,
+    ].join("\n");
+    headers["X-Correlation-ID"] = correlationId;
+    headers["X-SOAIA-Operator-ID"] = operator.operatorId;
+    headers["X-SOAIA-Operator-Role"] = operator.role;
+    headers["X-SOAIA-Auth-Timestamp"] = timestamp;
+    headers["X-SOAIA-Content-SHA256"] = contentSha256;
+    headers["X-SOAIA-Auth-Signature"] = createHmac("sha256", secret)
+      .update(signaturePayload)
+      .digest("hex");
+  }
   const response = await fetchImpl(`${coreBaseUrl(environment)}${path}`, {
     method,
     headers,
-    body: body === undefined ? undefined : JSON.stringify(body),
+    body: bodyText,
     cache: "no-store",
   });
   const text = await response.text();
@@ -81,4 +120,3 @@ export async function coreRequest(
   }
   return payload;
 }
-

--- a/apps/web/src/server/operator-context.mjs
+++ b/apps/web/src/server/operator-context.mjs
@@ -1,0 +1,11 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const operatorStorage = new AsyncLocalStorage();
+
+export function withOperatorContext(operator, callback) {
+  return operatorStorage.run(operator, callback);
+}
+
+export function currentOperatorContext() {
+  return operatorStorage.getStore() ?? null;
+}

--- a/apps/web/tests/auth.test.mjs
+++ b/apps/web/tests/auth.test.mjs
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import { createSign, generateKeyPairSync } from "node:crypto";
+import test from "node:test";
+
+import {
+  AuthError,
+  SESSION_COOKIE,
+  beginOidcLogin,
+  completeOidcLogin,
+  createSessionFromClaims,
+  logout,
+  requireRole,
+  requireSession,
+  resetAuthStateForTests,
+  roleFromClaims,
+  safeReturnTo,
+  safeSession,
+  sessionById,
+} from "../src/server/auth.mjs";
+import { coreRequest } from "../src/server/core-client.mjs";
+import { withOperatorContext } from "../src/server/operator-context.mjs";
+
+const config = {
+  issuer: "https://login.example.test/tenant/v2.0",
+  clientId: "pilot-client",
+  operatorGroup: "SOAIACORE_OPERATOR",
+  adminGroup: "SOAIACORE_ADMIN",
+  sessionTtlSeconds: 3_600,
+};
+
+test.beforeEach(() => resetAuthStateForTests());
+
+test("OIDC role mapping admits OPERATOR and ADMIN only", () => {
+  assert.equal(roleFromClaims({ roles: ["SOAIACORE_OPERATOR"] }, config), "OPERATOR");
+  assert.equal(roleFromClaims({ groups: ["SOAIACORE_ADMIN"] }, config), "ADMIN");
+  assert.throws(
+    () => roleFromClaims({ roles: ["READER"] }, config),
+    (error) => error instanceof AuthError && error.code === "OPERATOR_ROLE_FORBIDDEN",
+  );
+});
+
+test("opaque server-side session authenticates, expires, and exposes no identity token", () => {
+  const now = Math.floor(Date.now() / 1000);
+  const session = createSessionFromClaims(
+    {
+      iss: config.issuer,
+      sub: "sensitive-provider-subject",
+      exp: now + 10_000,
+      roles: ["SOAIACORE_OPERATOR"],
+      email: "operator@example.test",
+      access_token: "must-never-be-stored",
+    },
+    config,
+    now,
+  );
+  const request = new Request("https://pilot.example.test/api/operator/workflow", {
+    headers: { Cookie: `${SESSION_COOKIE}=${encodeURIComponent(session.id)}` },
+  });
+  assert.equal(requireSession(request).operatorId, session.operatorId);
+  assert.deepEqual(Object.keys(safeSession(session)).sort(), ["expires_at", "operator_id", "role"]);
+  assert.equal(JSON.stringify(session).includes("sensitive-provider-subject"), false);
+  assert.equal(JSON.stringify(session).includes("must-never-be-stored"), false);
+  assert.equal(sessionById(session.id, session.expiresAt), null);
+});
+
+test("ADMIN-only guard rejects OPERATOR and permits ADMIN", () => {
+  assert.throws(
+    () => requireRole({ role: "OPERATOR" }, "ADMIN"),
+    (error) => error instanceof AuthError && error.code === "ADMIN_ROLE_REQUIRED",
+  );
+  assert.equal(requireRole({ role: "ADMIN" }, "ADMIN").role, "ADMIN");
+});
+
+test("authenticated OPERATOR context reaches Core through the signed BFF boundary", async () => {
+  const now = Math.floor(Date.now() / 1000);
+  const session = createSessionFromClaims(
+    { iss: config.issuer, sub: "operator-flow", exp: now + 600, roles: [config.operatorGroup] },
+    config,
+    now,
+  );
+  let captured;
+  const result = await withOperatorContext(session, () =>
+    coreRequest("/v1/runs/run_test", {
+      environment: {
+        CORE_API_BASE_URL: "https://core.internal",
+        SOAIACORE_INTERNAL_AUTH_SECRET: "test-only-internal-auth-secret-32-bytes-minimum",
+      },
+      fetchImpl: async (url, options) => {
+        captured = { url, options };
+        return Response.json({ run_id: "run_test", status: "COMPLETED", mode: "MOCK" });
+      },
+    }),
+  );
+  assert.equal(result.mode, "MOCK");
+  assert.equal(captured.options.headers["X-SOAIA-Operator-ID"], session.operatorId);
+  assert.equal(captured.options.headers["X-SOAIA-Operator-Role"], "OPERATOR");
+});
+
+test("logout revokes the server-side session and expires the browser cookie", () => {
+  const now = Math.floor(Date.now() / 1000);
+  const session = createSessionFromClaims(
+    { iss: config.issuer, sub: "logout-flow", exp: now + 600, roles: [config.operatorGroup] },
+    config,
+    now,
+  );
+  const environment = {
+    SOAIACORE_OIDC_ISSUER: config.issuer,
+    SOAIACORE_OIDC_CLIENT_ID: config.clientId,
+    SOAIACORE_OIDC_CLIENT_SECRET: "client-secret",
+    SOAIACORE_WEB_BASE_URL: "https://pilot.example.test",
+  };
+  const response = logout(
+    new Request("https://pilot.example.test/api/auth/logout", {
+      method: "POST",
+      headers: { Cookie: `${SESSION_COOKIE}=${session.id}` },
+    }),
+    { environment },
+  );
+  assert.equal(response.status, 303);
+  assert.match(response.headers.get("set-cookie"), /Max-Age=0/);
+  assert.equal(sessionById(session.id), null);
+});
+
+test("unauthenticated requests and unsafe post-login redirects are rejected", () => {
+  const request = new Request("https://pilot.example.test/api/operator/workflow");
+  assert.throws(
+    () => requireSession(request),
+    (error) => error instanceof AuthError && error.code === "AUTHENTICATION_REQUIRED",
+  );
+  assert.equal(safeReturnTo("https://attacker.example/"), "/");
+  assert.equal(safeReturnTo("//attacker.example/"), "/");
+  assert.equal(safeReturnTo("/workflow"), "/workflow");
+});
+
+test("OIDC authorization-code flow validates RS256, PKCE transaction, and creates opaque cookie", async () => {
+  const { privateKey, publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const jwk = publicKey.export({ format: "jwk" });
+  jwk.kid = "pilot-key";
+  jwk.alg = "RS256";
+  jwk.use = "sig";
+  const environment = {
+    SOAIACORE_OIDC_ISSUER: config.issuer,
+    SOAIACORE_OIDC_CLIENT_ID: config.clientId,
+    SOAIACORE_OIDC_CLIENT_SECRET: "oidc-client-secret-never-in-browser",
+    SOAIACORE_WEB_BASE_URL: "https://pilot.example.test",
+    SOAIACORE_OIDC_OPERATOR_GROUP: config.operatorGroup,
+  };
+  const metadata = {
+    issuer: config.issuer,
+    authorization_endpoint: `${config.issuer}/authorize`,
+    token_endpoint: `${config.issuer}/token`,
+    jwks_uri: `${config.issuer}/keys`,
+  };
+  let idToken;
+  const fetchImpl = async (url, options = {}) => {
+    if (url.endsWith("/.well-known/openid-configuration")) return Response.json(metadata);
+    if (url === metadata.token_endpoint) {
+      assert.equal(options.body.get("client_secret"), environment.SOAIACORE_OIDC_CLIENT_SECRET);
+      assert.ok(options.body.get("code_verifier"));
+      return Response.json({ id_token: idToken });
+    }
+    if (url === metadata.jwks_uri) return Response.json({ keys: [jwk] });
+    throw new Error(`Unexpected request: ${url}`);
+  };
+  const start = await beginOidcLogin(
+    new Request("https://pilot.example.test/api/auth/login?return_to=/workflow"),
+    { environment, fetchImpl },
+  );
+  const authorization = new URL(start.headers.get("location"));
+  const state = authorization.searchParams.get("state");
+  const nonce = authorization.searchParams.get("nonce");
+  const header = base64urlJson({ alg: "RS256", kid: jwk.kid, typ: "JWT" });
+  const claims = base64urlJson({
+    iss: config.issuer,
+    sub: "provider-subject",
+    aud: config.clientId,
+    exp: Math.floor(Date.now() / 1000) + 600,
+    nonce,
+    roles: [config.operatorGroup],
+  });
+  const signer = createSign("RSA-SHA256");
+  signer.update(`${header}.${claims}`);
+  signer.end();
+  idToken = `${header}.${claims}.${signer.sign(privateKey).toString("base64url")}`;
+  const stateCookie = start.headers.get("set-cookie").split(";")[0];
+  const callback = await completeOidcLogin(
+    new Request(`https://pilot.example.test/api/auth/callback?code=code-1&state=${state}`, {
+      headers: { Cookie: stateCookie },
+    }),
+    { environment, fetchImpl },
+  );
+  const setCookie = callback.headers.get("set-cookie");
+  assert.equal(callback.status, 302);
+  assert.equal(callback.headers.get("location"), "https://pilot.example.test/workflow");
+  assert.match(setCookie, /HttpOnly/);
+  assert.match(setCookie, /Secure/);
+  assert.equal(setCookie.includes(environment.SOAIACORE_OIDC_CLIENT_SECRET), false);
+  const sessionCookie = setCookie.match(/__Host-soaiacore_session=([^;,]+)/)?.[0];
+  assert.ok(sessionCookie);
+  const session = requireSession(
+    new Request("https://pilot.example.test/api/operator/workflow", {
+      headers: { Cookie: sessionCookie },
+    }),
+  );
+  assert.equal(session.role, "OPERATOR");
+});
+
+function base64urlJson(value) {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}

--- a/apps/web/tests/core-client.test.mjs
+++ b/apps/web/tests/core-client.test.mjs
@@ -4,10 +4,17 @@ import path from "node:path";
 import test from "node:test";
 import { CoreApiError, coreBaseUrl, coreRequest } from "../src/server/core-client.mjs";
 
+const internalSecret = "test-only-internal-auth-secret-32-bytes-minimum";
+const operatorContext = { operatorId: "op_0123456789abcdef01234567", role: "OPERATOR" };
+
 test("WEB_BFF uses CORE_API_BASE_URL only on the server request", async () => {
   let captured;
   const payload = await coreRequest("/v1/runs/run_test", {
-    environment: { CORE_API_BASE_URL: "https://core.internal" },
+    environment: {
+      CORE_API_BASE_URL: "https://core.internal",
+      SOAIACORE_INTERNAL_AUTH_SECRET: internalSecret,
+    },
+    operatorContext,
     fetchImpl: async (url, options) => {
       captured = { url, options };
       return new Response(JSON.stringify({ run_id: "run_test", status: "QUEUED" }), {
@@ -18,6 +25,10 @@ test("WEB_BFF uses CORE_API_BASE_URL only on the server request", async () => {
   });
   assert.equal(captured.url, "https://core.internal/v1/runs/run_test");
   assert.equal(captured.options.cache, "no-store");
+  assert.equal(captured.options.headers["X-SOAIA-Operator-ID"], operatorContext.operatorId);
+  assert.equal(captured.options.headers["X-SOAIA-Operator-Role"], "OPERATOR");
+  assert.match(captured.options.headers["X-SOAIA-Auth-Signature"], /^[a-f0-9]{64}$/);
+  assert.equal(JSON.stringify(captured).includes(internalSecret), false);
   assert.equal(payload.run_id, "run_test");
 });
 
@@ -34,7 +45,11 @@ test("WEB_BFF exposes only safe idempotency response metadata", async () => {
     body: { name: "Synthetic project" },
     idempotencyKey: "web-create-project-request-1",
     includeResponseMetadata: true,
-    environment: { CORE_API_BASE_URL: "https://core.internal" },
+    environment: {
+      CORE_API_BASE_URL: "https://core.internal",
+      SOAIACORE_INTERNAL_AUTH_SECRET: internalSecret,
+    },
+    operatorContext,
     fetchImpl: async (_url, options) => {
       assert.equal(options.headers["Idempotency-Key"], "web-create-project-request-1");
       return new Response(JSON.stringify({ project_id: "prj_test" }), {

--- a/docs/security/P1_OIDC_SESSION_RBAC_GATE_2026-08-26.md
+++ b/docs/security/P1_OIDC_SESSION_RBAC_GATE_2026-08-26.md
@@ -1,0 +1,54 @@
+# P1 OIDC, session and RBAC gate
+
+Issue: #18
+Classification: `SECURITY_GATE / IMPLEMENTATION_DECISION`
+
+## Decision
+
+The controlled pilot authenticates operators at the Web boundary with OIDC Authorization Code + PKCE. Web retains an opaque session identifier in a `Secure`, `HttpOnly`, `SameSite=Lax` cookie and stores the session record server-side. OIDC access tokens, ID tokens, provider subjects, email addresses and client secrets are not retained in the session or returned to the browser.
+
+Web derives a stable pseudonymous `operator_id` from the OIDC issuer and subject. Each Web-to-Core `/v1/*` request carries that identifier, the mapped role, a correlation ID and a short-lived HMAC signature covering the HTTP method, path/query and request-body digest. Core rejects missing, expired, malformed, tampered or unauthorized contexts before entering a product handler. Health endpoints remain available without operator credentials.
+
+This preserves the existing browser → Web/BFF → Core boundary. The browser never receives Core, PostgreSQL or Blob credentials and cannot construct the internal signature.
+
+## Minimal roles
+
+- `OPERATOR`: may enter the portal and execute the approved MOCK pilot flow.
+- `ADMIN`: includes operator access and is accepted by the reusable ADMIN-only guard.
+- `REVIEWER`: not introduced because the current pilot ReviewPolicy does not require an interactive reviewer role.
+
+There are currently no administrative mutation screens. Any future ADMIN-only route must call the existing role guard and include a negative OPERATOR test.
+
+## Required runtime configuration
+
+All values are server-side. Secret values must come from the approved deployment secret source and must never be committed.
+
+| Variable | Purpose |
+|---|---|
+| `SOAIACORE_OIDC_ISSUER` | Exact HTTPS OIDC issuer URL |
+| `SOAIACORE_OIDC_CLIENT_ID` | Confidential Web client identifier |
+| `SOAIACORE_OIDC_CLIENT_SECRET` | Confidential Web client secret |
+| `SOAIACORE_WEB_BASE_URL` | Canonical HTTPS Web origin used for the redirect URI |
+| `SOAIACORE_OIDC_OPERATOR_GROUP` | Role/group value mapped to `OPERATOR`; default `SOAIACORE_OPERATOR` |
+| `SOAIACORE_OIDC_ADMIN_GROUP` | Role/group value mapped to `ADMIN`; default `SOAIACORE_ADMIN` |
+| `SOAIACORE_SESSION_TTL_SECONDS` | Maximum session lifetime; default 28,800 seconds |
+| `SOAIACORE_INTERNAL_AUTH_SECRET` | At least 32-byte shared secret mounted independently in Web and Core |
+| `SOAIACORE_INTERNAL_AUTH_REQUIRED` | Core fail-closed switch; defaults to `true` from environment |
+
+The registered redirect URI is `${SOAIACORE_WEB_BASE_URL}/api/auth/callback`. Insecure HTTP is always rejected by runtime configuration validation.
+
+## Session and deployment constraint
+
+The minimal pilot session store is process-local and intentionally bounded to the existing Web scale of zero-to-one replica. A restart expires all sessions safely. Horizontal Web scaling requires a shared encrypted session store and belongs to production hardening (#19); do not increase Web above one replica before that control exists.
+
+## Public and protected routes
+
+- Public: `/login`, `/forbidden`, `/api/auth/*`, `/api/health/live`, `/api/health/ready`.
+- Protected: the portal, workflow, runs, receipts, context/evidence views and every `/api/operator/*` or `/api/runs/*` BFF route.
+- Core: every `/v1/*` route requires signed operator context when the default environment configuration is used.
+
+## Acceptance evidence
+
+Automated tests cover OIDC discovery, Authorization Code + PKCE, RS256 verification, role mapping, opaque session creation/expiry, unsafe redirect rejection, ADMIN enforcement, Web-to-Core signing, missing/tampered/expired context rejection and secret non-disclosure. The existing MOCK lifecycle and BFF regression suites remain required.
+
+No Architecture v0.7 change is required.

--- a/packages/python-runtime/src/soaiacore_runtime/config.py
+++ b/packages/python-runtime/src/soaiacore_runtime/config.py
@@ -51,6 +51,8 @@ class RuntimeSettings:
     azure_container_app_job_name: str | None = None
     azure_management_api_version: str = "2024-03-01"
     dispatch_timeout_seconds: float = 10.0
+    internal_auth_required: bool = True
+    internal_auth_secret: str | None = None
 
     @classmethod
     def from_env(cls) -> "RuntimeSettings":
@@ -80,5 +82,10 @@ class RuntimeSettings:
             dispatch_timeout_seconds=float(
                 os.getenv("SOAIACORE_DISPATCH_TIMEOUT_SECONDS", "10")
             ),
+            internal_auth_required=os.getenv(
+                "SOAIACORE_INTERNAL_AUTH_REQUIRED", "true"
+            ).lower()
+            not in {"0", "false", "no"},
+            internal_auth_secret=os.getenv("SOAIACORE_INTERNAL_AUTH_SECRET"),
         )
 

--- a/receipts/ISSUE_18_SECURITY_GATE_2026-08-26.json
+++ b/receipts/ISSUE_18_SECURITY_GATE_2026-08-26.json
@@ -1,0 +1,33 @@
+{
+  "issue": "#18",
+  "issue_18_status": "PASS_LOCAL_READY_FOR_IDP_BINDING",
+  "recorded_utc": "2026-08-27T03:30:19.8089165Z",
+  "branch": "feat/p1-sec-oidc-session-rbac",
+  "baseline_commit": "b81f45e",
+  "authentication": "PASS (OIDC Authorization Code + PKCE; RS256 validation)",
+  "server_side_session": "PASS (opaque HttpOnly/Secure cookie; process-local store; expiry and logout verified)",
+  "rbac": "PASS (OPERATOR and ADMIN; ADMIN negative/positive enforcement verified)",
+  "web_bff_boundary": "PASS (all product pages and BFF routes require authenticated context)",
+  "core_authorization": "PASS (fail-closed signed operator context on /v1/*)",
+  "operator_audit_identity": "PASS (pseudonymous operator_id and correlation_id; no provider subject retained)",
+  "provider_mode": "MOCK",
+  "tests": {
+    "python_gate": "37 passed, 0 failed, 0 skipped, 1 deprecation warning",
+    "web_suite": "26 passed, 0 failed, 0 skipped",
+    "web_production_build": "PASS",
+    "total_test_cases_executed": 63,
+    "pass": 63,
+    "fail": 0,
+    "skipped": 0,
+    "blocked": 0
+  },
+  "live_oidc_provider_binding": "NOT_CONFIGURED_IN_LOCAL_GATE",
+  "files_changed_this_execution": 36,
+  "final_diff_stat": "36 files changed, 1330 insertions(+), 91 deletions(-)",
+  "architecture_change_required": "NO",
+  "security_regression": "NONE",
+  "azure_terraform_ghcr_changed": false,
+  "ready_for_commit": "YES",
+  "blocker": "Live controlled-pilot deployment remains blocked until approved IdP values and secrets are mounted by #19.",
+  "next_action": "Commit and open the Issue #18 PR. After merge, execute #19 production hardening and bind the approved OIDC provider without increasing Web above one replica."
+}

--- a/receipts/ISSUE_18_SECURITY_GATE_2026-08-26.md
+++ b/receipts/ISSUE_18_SECURITY_GATE_2026-08-26.md
@@ -1,0 +1,25 @@
+# Issue #18 · OIDC/session/RBAC security gate
+
+- `ISSUE_18_STATUS`: **PASS_LOCAL_READY_FOR_IDP_BINDING**
+- `AUTHENTICATION`: **PASS** — OIDC Authorization Code + PKCE and RS256 verification
+- `SERVER_SIDE_SESSION`: **PASS** — opaque `HttpOnly`/`Secure` session, expiry and logout
+- `RBAC`: **PASS** — `OPERATOR` and `ADMIN`; ADMIN enforcement tested
+- `WEB_BFF_BOUNDARY`: **PASS** — product pages and BFF routes require a session
+- `CORE_AUTHORIZATION`: **PASS** — `/v1/*` fails closed without signed operator context
+- `AUDIT_IDENTITY`: **PASS** — pseudonymous operator and correlation IDs only
+- `PROVIDER_MODE`: `MOCK`
+- `TESTS_TOTAL/PASS/FAIL/SKIPPED/BLOCKED`: **63 / 63 / 0 / 0 / 0**
+- `PYTHON_GATE`: **37 passed**, one non-blocking Starlette deprecation warning
+- `WEB_SUITE`: **26 passed**
+- `WEB_PRODUCTION_BUILD`: **PASS**
+- `FILES_CHANGED_THIS_EXECUTION`: `36`
+- `FINAL_DIFF_STAT`: `36 files changed, 1330 insertions(+), 91 deletions(-)`
+- `ARCHITECTURE_CHANGE_REQUIRED`: **NO**
+- `SECURITY_REGRESSION`: **NONE**
+- `AZURE_TERRAFORM_GHCR_CHANGED`: **NO**
+- `READY_FOR_COMMIT`: **YES**
+- `BLOCKER`: live pilot deployment still requires approved IdP configuration and secret mounting through #19
+
+The local gate uses a cryptographically valid mocked OIDC provider/JWKS. No real identity token, client secret, session identifier or internal HMAC secret is recorded in this receipt.
+
+The process-local server session store is approved only for the existing Web scale of zero-to-one replica. Horizontal scaling remains blocked until #19 introduces a shared encrypted session store.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,7 @@ def settings() -> RuntimeSettings:
         fixture_dir=ROOT / "packages" / "mock-fixtures" / "v1",
         storage_account_name=None,
         storage_container_name=None,
+        internal_auth_required=False,
     )
 
 


### PR DESCRIPTION
## Summary
- Adds OIDC Authorization Code + PKCE authentication with RS256 verification and opaque server-side sessions.
- Enforces OPERATOR/ADMIN RBAC across product pages and BFF routes.
- Makes Core `/v1/*` fail closed behind short-lived signed operator context covering method, query, and body digest.
- Preserves MOCK lifecycle and browser → Web/BFF → Core boundary; no browser credentials or identity tokens are exposed.

## Validation
- Python/PostgreSQL gate: 37 passed, 0 failed.
- Web auth/BFF suite: 26 passed, 0 failed.
- Next.js production build: PASS.
- Azure/Terraform/GHCR: unchanged.

## Deployment note
The live approved IdP values and secrets must be mounted by #19. The process-local session store is limited to the existing Web scale of 0–1 replica; horizontal scaling requires the shared encrypted store in #19.

Closes #18