### PR TITLE
docs(governance): adopt canonical GitHub hygiene controls

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Scope
+
+Describe the intended outcome and affected surface.
+
+## Evidence state
+
+- [ ] Current state is classified accurately (VERIFIED / SPECIFIED / EXPERIMENTAL / HISTORICAL / VISION, as applicable)
+- [ ] Validation performed is stated below
+- [ ] Remaining evidence gaps or exceptions are explicit
+
+## Governance & technical hygiene
+
+- [ ] No live secrets, tokens, keys, passwords, secret-bearing state, or plan artifacts are committed
+- [ ] Historical/non-canonical material is visibly labeled at direct entry points
+- [ ] Principal references (CODEOWNERS, assignees, OIDC subjects, workflows, packages, links) are current where affected
+- [ ] Temporary branch cleanup or rescue disposition is explicit
+- [ ] Terraform changes identify backend handling and exact plan impact before apply
+- [ ] No runtime claim exceeds the available receipt/evidence
+- [ ] Automated review findings are either resolved or explicitly adjudicated
+
+## Validation / receipt
+
+State the commands/checks and the actual result.
+
+## Human adjudication / exception
+
+`NONE`, or record the authorized deviation, reason, risk, and evidence state.
+
+> Canonical policy: `SOAIACORE-Corporation/policy-continuidad/policies/GITHUB_GOVERNANCE_HYGIENE.md`

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,23 @@
+# Repository Governance
+
+**Status:** CANONICAL REFERENCE · ACTIVE
+
+This repository follows the SOAiaCore GitHub governance and technical-hygiene policy maintained in:
+
+`SOAIACORE-Corporation/policy-continuidad/policies/GITHUB_GOVERNANCE_HYGIENE.md`
+
+The policy governs evidence-state clarity, document canonicality, branch and pull-request hygiene, secret handling, Terraform state/plan discipline, public metadata, review closure, deviations, and minimum receipts.
+
+Repository-specific controls may be stricter. Where this repository's architecture, security contracts, validation gates, or runbooks impose a stricter requirement, the stricter requirement governs.
+
+## Required operating pattern
+
+Material changes should follow:
+
+`CONTEXT → SYNC → PRECHECK → EXECUTE / CHANGE → VALIDATE → RECEIPT`
+
+Automation and gates provide evidence and control. Human adjudication remains authoritative; an exception must be recorded rather than misrepresented as a passed gate.
+
+## Infrastructure rule
+
+For Terraform-managed Azure changes, configuration or static validation is not equivalent to runtime evidence. A cloud state may be called VERIFIED only after the authorized backend, saved plan/apply where applicable, runtime validation, and receipt exist.


### PR DESCRIPTION
Adopts the canonical SOAiaCore GitHub governance/hygiene policy in the primary technical repository without duplicating the policy text.

Adds:
- `GOVERNANCE.md` pointer and repository-specific precedence rule;
- PR checklist for evidence state, secrets, principal references, branch cleanup, Terraform backend/plan handling, runtime-claim discipline, and review closure.

No runtime or infrastructure mutation.