### PR TITLE
infra(state): adopt discovered backend before creating new state store

### DIFF
--- a/infra/azure/state-bootstrap/README.md
+++ b/infra/azure/state-bootstrap/README.md
@@ -1,42 +1,89 @@
-# Azure Terraform Remote-State Bootstrap
+# Azure Terraform Remote-State Bootstrap / Adoption
 
-**State:** SPECIFIED · NOT YET CLOUD-APPLIED
+**State:** SPECIFIED + STATIC_VALIDATED · EXISTING AZURE RESOURCES DISCOVERED · AUTHORITY NOT YET VERIFIED
 
-This directory codifies the dedicated Azure Blob state store required by the controlled-pilot hardening gate. It is deliberately outside `infra/azure/p0/` so the workload stack cannot accidentally destroy its own authoritative state store.
+This directory codifies the dedicated Azure Blob state store required by the controlled-pilot hardening gate. It lives outside `infra/azure/p0/` so the workload stack cannot accidentally destroy its own authoritative state store.
 
-## Purpose
+## Current discovery
 
-Create only the control-plane resources required by the `azurerm` backend:
+Read-only Azure discovery on 2026-09-02 found an existing dedicated state resource group and storage account:
 
-- dedicated resource group;
-- StorageV2 account with TLS 1.2 minimum;
-- anonymous Blob access disabled;
-- shared-key authorization disabled;
-- Microsoft Entra authentication as the default;
-- deny-by-default storage network rules, with only explicitly approved bootstrap IP ranges when a private operator path is not available;
-- Blob versioning enabled;
-- Blob/container soft delete enabled;
-- private state container;
-- `CanNotDelete` management lock plus Terraform `prevent_destroy` guards;
-- optional `Storage Blob Data Contributor` assignments for explicitly supplied Entra principals.
+- resource group: `rg-soaiacore-tfstate-34utxi`
+- storage account: `stsoaiacoretf34utxi`
+- region: `eastus2`
 
-This bootstrap does **not** change the SOAiaCore workload, GHCR bindings, Container Apps, PostgreSQL, or application image digests.
+Observed management-plane controls include HTTPS-only transport, TLS 1.2 minimum, anonymous Blob access disabled, shared-key access disabled, and deny-by-default storage network rules.
+
+The container name, actual state blob/key, effective versioning/soft-delete settings, and authoritative-state status remain evidence-gated. A Cloud Shell data-plane listing returned 403 because that session used an ephemeral MSI identity rather than the user identity holding Blob Data Contributor.
+
+**Do not create a second state store while the discovered resources may already be authoritative.**
+
+## Create-new versus adopt-existing
+
+### Adopt existing — current default path
+
+When the resource group/storage account already exist:
+
+1. verify exact resource identifiers through Azure management plane;
+2. verify container name and recovery controls;
+3. verify a durable Entra data-plane identity/path;
+4. import the existing Azure resources into the bootstrap Terraform state before planning changes;
+5. run a saved plan and require **zero delete/replace actions**;
+6. reconcile only missing hardening controls (for example a missing `CanNotDelete` lock) through a reviewed plan;
+7. determine whether workload state is already authoritative before running any `-migrate-state` operation.
+
+Example import pattern — use only verified identifiers and keep the bootstrap state outside Git:
+
+```powershell
+terraform init -backend=false
+terraform import -var-file=state-bootstrap.tfvars azurerm_resource_group.state "/subscriptions/<subscription-id>/resourceGroups/<verified-resource-group>"
+terraform import -var-file=state-bootstrap.tfvars azurerm_storage_account.state "/subscriptions/<subscription-id>/resourceGroups/<verified-resource-group>/providers/Microsoft.Storage/storageAccounts/<verified-storage-account>"
+terraform import -var-file=state-bootstrap.tfvars azurerm_storage_container.state "https://<verified-storage-account>.blob.core.windows.net/<verified-container>"
+```
+
+Import IDs must be verified against the AzureRM provider version in use before execution. If the provider requires a different container import identifier, STOP and use the provider-documented form rather than guessing.
+
+### Create new — exception path only
+
+Creating a new state store is allowed only when read-only evidence establishes that no authoritative existing backend should be adopted. A create plan must contain only the intended dedicated resource group, StorageV2 account, private container, deletion lock, and explicitly requested RBAC assignments. Any unexpected duplicate, delete, or replace action is a STOP condition.
 
 ## Required operator inputs
 
-Supply these outside Git:
+Supply outside Git:
 
 - authorized Azure `subscription_id`;
-- a globally unique lowercase `storage_account_name`;
-- the Entra object IDs that require state read/write access;
-- an approved private path or, only for a controlled bootstrap window, the minimum required operator IPv4/CIDR ranges through `allowed_ip_ranges`;
-- any approved tag overrides.
+- exact verified `resource_group_name`;
+- exact verified `storage_account_name`;
+- exact verified `container_name`;
+- Entra object IDs that require state read/write access;
+- an approved private path or the minimum temporary operator IPv4/CIDR ranges through `allowed_ip_ranges` when no private operator path is available;
+- approved tag overrides.
 
-Do not commit a real `.tfvars`, state, plan, JSON plan, or backend configuration file. Do not use an unrestricted public storage endpoint.
+The resource-group and container variables intentionally have **no generic defaults**. This prevents accidental creation of parallel state infrastructure from convenient placeholder names.
 
-## Bootstrap sequence
+Do not commit real `.tfvars`, Terraform state, saved plans, JSON plans, backend configuration, tokens, keys, or raw connection strings.
 
-From this directory, using Terraform 1.15.x and an authenticated Azure operator:
+## Desired hardening
+
+The module declares:
+
+- StorageV2 with TLS 1.2 minimum;
+- anonymous Blob access disabled;
+- shared-key authorization disabled;
+- Microsoft Entra authentication as default;
+- deny-by-default storage network rules;
+- Blob versioning enabled;
+- Blob/container soft delete;
+- private state container;
+- `CanNotDelete` management lock;
+- Terraform `prevent_destroy` guards;
+- optional `Storage Blob Data Contributor` assignments for explicitly supplied Entra principals.
+
+The module does **not** change SOAiaCore workload resources, GHCR bindings, Container Apps, PostgreSQL, or application image digests.
+
+## Validation / plan sequence
+
+Using Terraform 1.15.x and an authenticated Azure operator:
 
 ```powershell
 terraform fmt -check
@@ -46,39 +93,27 @@ terraform plan -out=state-bootstrap.tfplan -var-file=state-bootstrap.tfvars
 terraform show -json state-bootstrap.tfplan > state-bootstrap.tfplan.json
 ```
 
-Review the exact plan before apply. A bootstrap plan is expected to create only the dedicated state resource group, storage account, private container, deletion lock, and explicitly requested RBAC assignments. Any delete/replace action is a STOP condition.
-
-After human adjudication of the saved plan:
-
-```powershell
-terraform apply state-bootstrap.tfplan
-```
-
-The bootstrap's own local state is an operator-restricted control-plane artifact. Keep it outside Git and protect it according to the same state-handling policy; do not treat it as application state.
-
-### Deletion guard
-
-The resource group and storage account use `prevent_destroy`, and the state account also receives an Azure `CanNotDelete` management lock. Intentional decommission therefore requires a **separate reviewed unlock change** after authoritative workload state has been migrated elsewhere and verified. Do not remove these protections as part of a routine workload teardown.
+Review the exact saved plan. Delete/replace actions or unplanned duplicate resources are STOP conditions. Apply only the exact reviewed saved plan after human adjudication.
 
 ## Bind the controlled pilot
 
-After the state store exists, create an operator-restricted copy of `../p0/backend.production.hcl.example` and replace only the non-secret identifiers with the verified bootstrap outputs:
+After authoritative backend resources and the container are verified, create an operator-restricted copy of `../p0/backend.production.hcl.example`:
 
 ```hcl
-resource_group_name  = "<verified resource_group_name output>"
-storage_account_name = "<verified storage_account_name output>"
-container_name       = "<verified container_name output>"
-key                  = "soaiacore/controlled-pilot/terraform.tfstate"
+resource_group_name  = "<verified resource_group_name>"
+storage_account_name = "<verified storage_account_name>"
+container_name       = "<verified container_name>"
+key                  = "<verified authoritative state key>"
 use_azuread_auth     = true
 ```
 
-Then migrate deliberately from the authorized P0 state location:
+Run `terraform init -migrate-state` **only if evidence proves migration is necessary**. If the state blob is already authoritative, bind to it without manufacturing a migration event.
 
-```powershell
-terraform init -migrate-state -backend-config=<protected-backend-file>
-```
+Do not claim `remote_backend_initialized = true` until the backend can be read with Entra authorization through the approved network path and a subsequent saved workload plan is reviewed without delete/replace actions.
 
-Do not claim `remote_backend_initialized = true` until the migrated backend can be read using Entra authorization through the approved network path and the subsequent saved workload plan is reviewed without delete/replace actions.
+## Naming rule
+
+Do not rename the state container for aesthetics while authority is unresolved. Azure container renaming is effectively a create/copy/delete migration and introduces unnecessary state risk. Cosmetic naming can be reconsidered only after authority, backup/recovery, and rollback are proven.
 
 ## Required receipt
 
@@ -86,13 +121,13 @@ Record only non-secret evidence:
 
 - subscription scope identifier as permitted by policy;
 - resource group / storage account / container names;
-- RBAC principal object IDs or approved redacted identifiers;
-- deny-by-default network rule state and approved access path;
+- approved/redacted RBAC principal identifiers;
+- deny-by-default network state and approved access path;
 - versioning and retention state;
 - anonymous/shared-key access state;
 - deletion lock / destroy-guard state;
-- `terraform init -migrate-state` result;
-- post-migration plan add/change/destroy counts;
-- `remote_backend_initialized` and `plan_no_destroy_verified` gate states.
+- adoption/import or migration result;
+- post-binding workload plan add/change/destroy counts;
+- `remote_backend_initialized` and `plan_no_destroy_verified` states.
 
-Never include access tokens, storage keys, state contents, secret values, or raw connection strings in receipts.
+Never include state contents, access tokens, storage keys, secret values, or raw connection strings in receipts.

--- a/infra/azure/state-bootstrap/variables.tf
+++ b/infra/azure/state-bootstrap/variables.tf
@@ -11,13 +11,17 @@ variable "location" {
 }
 
 variable "resource_group_name" {
-  description = "Dedicated resource group for Terraform remote state."
+  description = "Exact dedicated resource group for Terraform remote state. Required explicitly to prevent accidental creation of a duplicate state store."
   type        = string
-  default     = "rg-soaiacore-tfstate"
+
+  validation {
+    condition     = length(trimspace(var.resource_group_name)) > 0
+    error_message = "resource_group_name must be supplied explicitly from verified Azure discovery."
+  }
 }
 
 variable "storage_account_name" {
-  description = "Globally unique Storage Account name for Terraform state. Lowercase letters and numbers only, 3-24 characters."
+  description = "Exact globally unique Storage Account name for Terraform state. Supply the verified existing name when adopting an existing backend."
   type        = string
 
   validation {
@@ -27,9 +31,13 @@ variable "storage_account_name" {
 }
 
 variable "container_name" {
-  description = "Private Blob container used by the azurerm backend."
+  description = "Exact private Blob container used by the azurerm backend. Required explicitly after management/data-plane verification; do not invent or rename for cosmetic reasons."
   type        = string
-  default     = "tfstate"
+
+  validation {
+    condition     = length(trimspace(var.container_name)) > 0
+    error_message = "container_name must be supplied explicitly from verified backend discovery."
+  }
 }
 
 variable "retention_days" {


### PR DESCRIPTION
Closes #40 when merged.

Azure discovery on 2026-09-02 found an existing dedicated Terraform-state RG/storage account. This PR removes generic resource-group/container defaults and makes the safe path **discover/adopt first** rather than create-first.

Changes:
- require explicit verified `resource_group_name` and `container_name` inputs;
- clarify `storage_account_name` as verified existing name when adopting;
- document import/adoption before any change plan;
- prohibit duplicate state-store creation while existing authority is unresolved;
- prohibit cosmetic container rename before authority/recovery/rollback are proven;
- preserve no-delete/no-replace and human-adjudication gates.

No Azure mutation, no Terraform cloud plan/apply, no state migration, no backend contents are included.