### PR TITLE
fix(terraform): preserve remote-state parity before CanNotDelete

### DIFF
--- a/infra/azure/state-bootstrap/main.tf
+++ b/infra/azure/state-bootstrap/main.tf
@@ -40,6 +40,15 @@ resource "azurerm_storage_account" "state" {
     default_action = "Deny"
     bypass         = ["AzureServices"]
     ip_rules       = var.allowed_ip_ranges
+
+    dynamic "private_link_access" {
+      for_each = var.private_link_access
+
+      content {
+        endpoint_resource_id = private_link_access.value.endpoint_resource_id
+        endpoint_tenant_id   = private_link_access.value.endpoint_tenant_id
+      }
+    }
   }
 
   blob_properties {

--- a/infra/azure/state-bootstrap/variables.tf
+++ b/infra/azure/state-bootstrap/variables.tf
@@ -57,6 +57,15 @@ variable "allowed_ip_ranges" {
   default     = []
 }
 
+variable "private_link_access" {
+  description = "Existing Storage firewall private-link access exceptions to preserve during adopt-first reconciliation. Supply only values verified from the authoritative Azure resource."
+  type = list(object({
+    endpoint_resource_id = string
+    endpoint_tenant_id   = string
+  }))
+  default = []
+}
+
 variable "state_principal_object_ids" {
   description = "Microsoft Entra object IDs allowed to read/write Terraform state through RBAC."
   type        = set(string)


### PR DESCRIPTION
## Purpose
Preserve verified live state-backend attributes before applying the missing `CanNotDelete` management lock for #38.

## Why
The isolated bootstrap adoption plan correctly showed `CREATE=1 / UPDATE=2 / DELETE=0 / REPLACE=0`, but attribute review found two incidental drift risks:
- existing `project=SOAIACORE` tags would be removed unless supplied as an operator tag override;
- existing Storage `network_rules.private_link_access` for the Microsoft Security data scanner would be removed because the bootstrap module did not model it.

## Change
- add optional `private_link_access` input to `infra/azure/state-bootstrap`;
- render verified private-link access entries dynamically in Storage network rules;
- keep `default_to_oauth_authentication=true` as the intended hardening target;
- `project=SOAIACORE` remains an explicit external tag override in the local adoption tfvars, consistent with the module's `tags` input.

## Safety
- no Azure apply;
- no backend migration;
- no workload state mutation;
- no secret values;
- next gate is a saved bootstrap plan from this exact branch head using the already-adopted isolated bootstrap state, requiring 0 delete / 0 replace and no incidental private-link or project-tag removal.

Related: #38, #40.