### PR TITLE
fix(soa-intelligence): classify expected backend network hold

### DIFF
--- a/.github/workflows/azure-soa-intelligence-auth-preflight.yml
+++ b/.github/workflows/azure-soa-intelligence-auth-preflight.yml
@@ -53,6 +53,7 @@ jobs:
           echo 'STATE_STORAGE_ACCOUNT_READ=PASS'
 
       - name: Inspect backend network posture read-only
+        id: network
         shell: bash
         env:
           AZURE_CORE_OUTPUT: json
@@ -78,10 +79,12 @@ jobs:
           echo "STATE_VNET_RULE_COUNT=$vnet_rule_count"
           echo "STATE_RESOURCE_ACCESS_RULE_COUNT=$resource_access_rule_count"
           echo "STATE_PRIVATE_ENDPOINT_COUNT=$private_endpoint_count"
+          echo "default_action=$default_action" >> "$GITHUB_OUTPUT"
           echo 'STATE_NETWORK_POSTURE_READ=PASS'
 
       - name: Verify Terraform state container data-plane access
         id: state_data
+        continue-on-error: true
         shell: bash
         env:
           AZURE_CORE_OUTPUT: json
@@ -97,10 +100,11 @@ jobs:
           echo 'STATE_CONTAINER_EXISTS=PASS'
           echo 'STATE_DATA_PLANE_READ=PASS'
 
-      - name: Record execution boundary
+      - name: Record and enforce execution boundary
         if: always()
         shell: bash
         run: |
+          set -euo pipefail
           echo 'OIDC_SUBJECT_SCOPE=TRUSTED_BRANCH_ONLY'
           echo 'AZURE_MUTATION=false'
           echo 'TERRAFORM_INIT=false'
@@ -108,8 +112,18 @@ jobs:
           echo 'TERRAFORM_APPLY=false'
           echo 'TERRAFORM_DESTROY=false'
           echo 'STATE_DATA_PLANE_OUTCOME=${{ steps.state_data.outcome }}'
+          echo 'STATE_NETWORK_DEFAULT_ACTION=${{ steps.network.outputs.default_action }}'
+
           if [ '${{ steps.state_data.outcome }}' = 'success' ]; then
             echo 'SOA_INTELLIGENCE_AZURE_AUTH_PREFLIGHT=PASS'
-          else
-            echo 'SOA_INTELLIGENCE_AZURE_AUTH_PREFLIGHT=HOLD_NETWORK'
+            exit 0
           fi
+
+          if [ '${{ steps.network.outputs.default_action }}' = 'Deny' ]; then
+            echo 'SOA_INTELLIGENCE_AZURE_AUTH_PREFLIGHT=HOLD_NETWORK'
+            echo 'EXPECTED_BACKEND_NETWORK_DENIAL=true'
+            exit 0
+          fi
+
+          echo 'SOA_INTELLIGENCE_AZURE_AUTH_PREFLIGHT=FAIL_UNEXPECTED_DATA_PLANE'
+          exit 1

--- a/.github/workflows/azure-soa-intelligence-auth-preflight.yml
+++ b/.github/workflows/azure-soa-intelligence-auth-preflight.yml
@@ -1,6 +1,7 @@
 name: Azure SOA Intelligence Auth Preflight
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - feature/soa-intelligence-a2-postgres-20260906-r2


### PR DESCRIPTION
## Purpose
Correct the CI semantics of the SOA Intelligence Azure auth preflight without changing Azure, IAM, firewall rules, Terraform state, or A2 runtime resources.

## Observed after #58 merge
`main` run `34044928572` showed:
- Azure OIDC login: PASS
- subscription context: PASS
- state RG/storage management-plane read: PASS
- backend network posture read: PASS
- state container data-plane read: FAILURE

This is the already-known expected hosted-runner boundary: the state storage account has network default action `Deny`, and we intentionally refused to open the backend firewall merely to make GitHub-hosted CI pass.

The old workflow correctly emitted `SOA_INTELLIGENCE_AZURE_AUTH_PREFLIGHT=HOLD_NETWORK` in its final step, but the failed data-plane step still made the overall workflow red.

## Change
- keep OIDC/login/context/management-plane checks fail-closed;
- mark the data-plane probe `continue-on-error`;
- capture network default action;
- if data-plane succeeds: `PASS`;
- if data-plane fails **and** network default action is `Deny`: emit `HOLD_NETWORK` / `EXPECTED_BACKEND_NETWORK_DENIAL=true` and keep CI green;
- if data-plane fails while default action is not `Deny`: fail the workflow as unexpected;
- add `workflow_dispatch` for explicit verification.

## Boundary
This PR performs **no Azure mutation** and does not broaden backend access. It is deliberately kept separate from the current A2 private-migration saved-plan authority so canonical `main` remains stable while that plan is generated.