### PR TITLE
fix(soa-intelligence): preserve A2 private-plan parity

### DIFF
--- a/infra/azure/soa-intelligence-dev/network.tf
+++ b/infra/azure/soa-intelligence-dev/network.tf
@@ -12,6 +12,10 @@ resource "azurerm_subnet" "postgresql" {
   virtual_network_name = azurerm_virtual_network.soa_intelligence.name
   address_prefixes     = ["10.60.10.0/24"]
 
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
+
   delegation {
     name = "postgresql-flexible-server"
 

--- a/infra/azure/soa-intelligence-dev/postgresql.tf
+++ b/infra/azure/soa-intelligence-dev/postgresql.tf
@@ -2,6 +2,7 @@ resource "azurerm_postgresql_flexible_server" "soa_intelligence" {
   name                          = "psql-soaintelligence-${var.environment}-${random_string.suffix.result}"
   resource_group_name           = azurerm_resource_group.soa_intelligence.name
   location                      = azurerm_resource_group.soa_intelligence.location
+  zone                          = "2"
   version                       = var.postgresql_version
   delegated_subnet_id           = azurerm_subnet.postgresql.id
   private_dns_zone_id           = azurerm_private_dns_zone.postgresql.id

--- a/infra/azure/soa-intelligence-dev/private_migration.tf
+++ b/infra/azure/soa-intelligence-dev/private_migration.tf
@@ -45,7 +45,7 @@ resource "azurerm_container_app_environment" "a2_migration" {
 }
 
 resource "azurerm_container_app_job" "a2_migration" {
-  name                         = "caj-${local.name_prefix}-migration"
+  name                         = "caj-soaintelligence-dev-migrate"
   location                     = azurerm_resource_group.soa_intelligence.location
   resource_group_name          = azurerm_resource_group.soa_intelligence.name
   container_app_environment_id = azurerm_container_app_environment.a2_migration.id


### PR DESCRIPTION
## Purpose
Correct the exact live-plan parity defects detected by the governed A2 private-migration saved-plan attempt. No Azure or database mutation is included.

## Evidence from rejected plan
The governed plan refreshed the closed 11-address A2 state, then rejected execution because it observed:
- PostgreSQL `zone = "2"` physically present but absent from canonical Terraform, producing an unauthorized in-place update;
- `Microsoft.Storage` service endpoint physically present on the PostgreSQL subnet but absent from canonical Terraform, producing an unauthorized in-place update;
- Container Apps Job name `caj-${local.name_prefix}-migration` exceeding Azure's 32-character name limit, aborting the plan before a valid 4-create action set could be produced.

Observed plan outcome: `3 add / 2 change / 0 destroy`, then provider validation error. Apply never ran.

## Exact correction
This PR changes exactly three files and three semantics:
1. Preserve PostgreSQL physical zone with `zone = "2"`.
2. Preserve the existing PostgreSQL-subnet `Microsoft.Storage` service endpoint.
3. Shorten the migration job name to `caj-soaintelligence-dev-migrate` (31 chars).

## Boundary
- no Terraform plan against Azure in this PR;
- no Terraform apply;
- no Azure resource mutation;
- no database mutation;
- no IAM/RBAC changes;
- no firewall/public-network changes;
- no P0 changes.

## Required next gate
After CI and merge, regenerate the governed saved plan from canonical `main`. It must be exactly:
**4 CREATE / 0 UPDATE / 0 DELETE / 0 REPLACE**.
Anything else remains fail-closed.

Tracks #60.