### PR TITLE
fix(a2): make Worker OCI runtime importable in ACA

### DIFF
--- a/.github/workflows/soa-intelligence-a2-private-migration-static.yml
+++ b/.github/workflows/soa-intelligence-a2-private-migration-static.yml
@@ -78,7 +78,7 @@ jobs:
           file=infra/azure/soa-intelligence-dev/private_migration.tf
           grep -F 'address_prefixes     = ["10.60.20.0/27"]' "$file"
           grep -F 'name = "Microsoft.App/environments"' "$file"
-          grep -F 'command = ["python", "-m", "soaiacore_worker", "a2-bootstrap"]' "$file"
+          grep -F 'command = ["/app/.venv/bin/python", "-m", "soaiacore_worker", "a2-bootstrap"]' "$file"
           grep -F 'replica_retry_limit          = 0' "$file"
           grep -F 'public_network_access_enabled = false' infra/azure/soa-intelligence-dev/postgresql.tf
           ! grep -R -E 'azurerm_postgresql_flexible_server_firewall_rule|azurerm_role_assignment' "$file"

--- a/.github/workflows/soa-intelligence-worker-runtime-smoke.yml
+++ b/.github/workflows/soa-intelligence-worker-runtime-smoke.yml
@@ -1,0 +1,115 @@
+name: SOA Intelligence Worker OCI Runtime Smoke
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/soa-intelligence-worker-runtime-smoke.yml
+      - apps/worker/**
+      - packages/python-runtime/**
+      - db/migrations/**
+      - db/a2_migrations/**
+      - infra/azure/soa-intelligence-dev/private_migration.tf
+      - pyproject.toml
+      - uv.lock
+      - .python-version
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/soa-intelligence-worker-runtime-smoke.yml
+      - apps/worker/**
+      - packages/python-runtime/**
+      - db/migrations/**
+      - db/a2_migrations/**
+      - infra/azure/soa-intelligence-dev/private_migration.tf
+      - pyproject.toml
+      - uv.lock
+      - .python-version
+
+permissions:
+  contents: read
+
+concurrency:
+  group: a2-worker-runtime-smoke-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  WORKER_IMAGE: local/soaiacore-worker-runtime-smoke
+
+jobs:
+  worker-runtime-smoke:
+    name: Worker OCI runtime contract
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out the authorized commit
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+
+      - name: Build Worker for linux/amd64
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
+        with:
+          context: .
+          file: apps/worker/Dockerfile
+          platforms: linux/amd64
+          load: true
+          push: false
+          provenance: false
+          build-args: VCS_REF=${{ github.sha }}
+          tags: ${{ env.WORKER_IMAGE }}:${{ github.sha }}
+
+      - name: Verify Worker module through exact runtime interpreter
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --entrypoint /app/.venv/bin/python \
+            "${WORKER_IMAGE}:${GITHUB_SHA}" \
+            -m soaiacore_worker --help >/dev/null
+          docker run --rm \
+            --entrypoint /app/.venv/bin/python \
+            "${WORKER_IMAGE}:${GITHUB_SHA}" \
+            -c 'import soaiacore_worker, soaiacore_runtime; print("WORKER_RUNTIME_IMPORT_PASS")'
+
+      - name: Verify runtime filesystem contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --entrypoint /bin/sh \
+            "${WORKER_IMAGE}:${GITHUB_SHA}" \
+            -c 'test -d /app/schemas && test -d /app/db/migrations && test -d /app/db/a2_migrations'
+
+      - name: Verify immutable Worker command contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual="$(docker image inspect "${WORKER_IMAGE}:${GITHUB_SHA}" --format '{{json .Config.Cmd}}')"
+          expected='["/app/.venv/bin/python","-m","soaiacore_worker","run-one"]'
+          test "${actual}" = "${expected}"
+          grep -F 'command = ["/app/.venv/bin/python", "-m", "soaiacore_worker", "a2-bootstrap"]' \
+            infra/azure/soa-intelligence-dev/private_migration.tf >/dev/null
+
+      - name: Record smoke receipt
+        shell: bash
+        run: |
+          {
+            echo '## SOA Intelligence Worker OCI runtime smoke'
+            echo
+            echo "- Commit: \`${GITHUB_SHA}\`"
+            echo '- Platform: `linux/amd64`'
+            echo '- `/app/.venv/bin/python -m soaiacore_worker --help`: `PASS`'
+            echo '- Worker/runtime imports: `PASS`'
+            echo '- Runtime migration directories: `PASS`'
+            echo '- Docker CMD explicit venv interpreter: `PASS`'
+            echo '- A2 migration Job command explicit venv interpreter: `PASS`'
+            echo '- LIVE_PROVIDER_CALLS: `0`'
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -5,7 +5,7 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy
-WORKDIR /src
+WORKDIR /app
 RUN python -m pip install --no-cache-dir uv==0.12.5
 COPY pyproject.toml uv.lock .python-version ./
 COPY packages/python-runtime/pyproject.toml packages/python-runtime/pyproject.toml
@@ -35,11 +35,11 @@ RUN apt-get update \
       bsdutils libblkid1 liblastlog2-2 libmount1 libsmartcols1 libuuid1 \
       login mount util-linux libssl3t64 openssl openssl-provider-legacy \
     && rm -rf /var/lib/apt/lists/*
-COPY --from=builder /src/.venv /app/.venv
+COPY --from=builder /app/.venv /app/.venv
 COPY schemas /app/schemas
 COPY contracts /app/contracts
 COPY db/migrations /app/db/migrations
 COPY db/a2_migrations /app/db/a2_migrations
 COPY packages/mock-fixtures /app/packages/mock-fixtures
 USER 65532:65532
-CMD ["python", "-m", "soaiacore_worker", "run-one"]
+CMD ["/app/.venv/bin/python", "-m", "soaiacore_worker", "run-one"]

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -14,7 +14,14 @@ COPY apps/core/pyproject.toml apps/core/pyproject.toml
 COPY apps/core/src apps/core/src
 COPY apps/worker/pyproject.toml apps/worker/pyproject.toml
 COPY apps/worker/src apps/worker/src
-RUN uv sync --frozen --no-dev --no-editable --package soaiacore-worker
+RUN uv sync \
+    --python /usr/local/bin/python \
+    --no-managed-python \
+    --no-python-downloads \
+    --frozen \
+    --no-dev \
+    --no-editable \
+    --package soaiacore-worker
 
 FROM --platform=linux/amd64 docker.io/library/python:3.12-slim-trixie@sha256:2c941e860699f878900b0edc2403613c234d4b32eda3cc9fa7036991a2a63c4a AS runtime
 ARG VCS_REF=uncommitted

--- a/infra/azure/soa-intelligence-dev/private_migration.tf
+++ b/infra/azure/soa-intelligence-dev/private_migration.tf
@@ -81,7 +81,7 @@ resource "azurerm_container_app_job" "a2_migration" {
       image   = var.migration_worker_image
       cpu     = 0.25
       memory  = "0.5Gi"
-      command = ["python", "-m", "soaiacore_worker", "a2-bootstrap"]
+      command = ["/app/.venv/bin/python", "-m", "soaiacore_worker", "a2-bootstrap"]
 
       env {
         name  = "SOAIACORE_PROVIDER_MODE"


### PR DESCRIPTION
## Root cause
The first authorized A2 bootstrap execution (`caj-soaintelligence-dev-migrate-eznz2iy`) pulled the exact canonical Worker digest successfully, created a pod, then the container exited with code 1. Historical console logs show:

`/usr/local/bin/python: No module named soaiacore_worker`

This proves the failure occurred before the Worker module entered its guarded bootstrap path. PostgreSQL migration code was not reached.

## Changes
- Build the Worker virtualenv directly at `/app/.venv` instead of building it under `/src/.venv` and relocating it.
- Use explicit `/app/.venv/bin/python` in the Worker image CMD.
- Use explicit `/app/.venv/bin/python -m soaiacore_worker a2-bootstrap` in the A2 Container Apps Job definition.
- Add `SOA Intelligence Worker OCI Runtime Smoke` CI that builds the actual Worker image and verifies:
  - exact venv interpreter can execute `-m soaiacore_worker --help`;
  - `soaiacore_worker` and `soaiacore_runtime` import successfully;
  - runtime migration directories exist;
  - Docker CMD and Terraform Job command use the explicit venv interpreter.
- The new smoke workflow also watches `db/a2_migrations/**`.

## Scope / governance
R1 code and CI only.

- Azure mutation: **NO**
- Database mutation: **NO**
- IAM mutation: **NO**
- Firewall/public PostgreSQL change: **NO**
- P0 mutation: **NO**
- Container Apps Job start: **NO**

The previously authorized single Job start is consumed and is not retried by this PR. A new immutable Worker digest and a new exact R2 gate are required before any second execution.