### PR TITLE
feat(soa-intelligence): add G3C1 candidate trace bridge

### DIFF
--- a/.github/workflows/soa-intelligence-g3c1-candidate.yml
+++ b/.github/workflows/soa-intelligence-g3c1-candidate.yml
@@ -1,0 +1,133 @@
+name: SOA Intelligence G3C1 Candidate Trace Bridge
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'feat/g3c1-candidate-trace-*'
+    paths:
+      - .github/workflows/soa-intelligence-g3c1-candidate.yml
+      - packages/python-runtime/src/soaiacore_runtime/candidate_eval.py
+      - packages/python-runtime/tests/test_alpha_g3c1_candidate_bridge.py
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/soa-intelligence-g3c1-candidate.yml
+      - packages/python-runtime/src/soaiacore_runtime/candidate_eval.py
+      - packages/python-runtime/tests/test_alpha_g3c1_candidate_bridge.py
+
+permissions:
+  contents: read
+
+concurrency:
+  group: g3c1-candidate-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deterministic-g3c1:
+    name: G3C1 candidate/oracle separation gate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 12
+
+    steps:
+      - name: Check out exact commit
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          fetch-depth: 0
+
+      - name: Enforce exact G3C1 R1 file boundary and immutable datasets
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin main --depth=1
+          changed="$(git diff --name-only origin/main...HEAD)"
+          printf '%s\n' "$changed"
+          test -n "$changed"
+          allowed='^(\.github/workflows/soa-intelligence-g3c1-candidate\.yml|packages/python-runtime/src/soaiacore_runtime/candidate_eval\.py|packages/python-runtime/tests/test_alpha_g3c1_candidate_bridge\.py)$'
+          if printf '%s\n' "$changed" | grep -Ev "$allowed"; then
+            echo 'G3C1_R1_SCOPE_VIOLATION=true'
+            exit 1
+          fi
+          test "$(git rev-parse HEAD:packages/python-runtime/golden/soa-alpha-golden-v0.1.json)" = '14996ad98169cc388312e237b18f00c6e34c83f2'
+          test "$(git rev-parse HEAD:packages/python-runtime/golden/soa-alpha-golden-v0.1.holdout-seal.json)" = '969a2040f52ccc721a50ad455b6f6ce5bc5e8cd8'
+          test "$(git rev-parse HEAD:packages/python-runtime/golden/soa-alpha-golden-v0.2.json)" = '76783ecb77cf19b69617c6d5c9b5ca879856634b'
+          test "$(git rev-parse HEAD:packages/python-runtime/golden/soa-alpha-golden-v0.2.holdout-seal.json)" = '6b7b3f9f9b24caaa0ed5961308707f53b457d264'
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: 3.12.14
+
+      - name: Compile G3C1 bridge surfaces
+        run: |
+          python -m py_compile \
+            packages/python-runtime/src/soaiacore_runtime/candidate_eval.py \
+            packages/python-runtime/tests/test_alpha_g3c1_candidate_bridge.py
+
+      - name: Run G3C1 and measurement regression tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}/packages/python-runtime/src
+          SOAIACORE_PROVIDER_MODE: MOCK
+        run: |
+          python -m pip install --disable-pip-version-check --no-cache-dir uv==0.12.5
+          uv sync --frozen
+          uv run --frozen pytest -q \
+            packages/python-runtime/tests/test_alpha_g3a_quality.py \
+            packages/python-runtime/tests/test_alpha_g3c0_integrity.py \
+            packages/python-runtime/tests/test_alpha_g3c1_candidate_bridge.py \
+            packages/python-runtime/tests/test_alpha_cognitive_loop_contract.py
+
+      - name: Validate public v0.2 commitment without Holdout payload
+        env:
+          PYTHONPATH: ${{ github.workspace }}/packages/python-runtime/src
+        run: |
+          uv run --frozen python - <<'PY'
+          import json
+          from collections import Counter
+          from pathlib import Path
+          from soaiacore_runtime.quality_eval import GoldenDatasetManifest, HoldoutSeal, verify_holdout_seal
+
+          root = Path('packages/python-runtime/golden')
+          manifest = GoldenDatasetManifest.model_validate(
+              json.loads((root / 'soa-alpha-golden-v0.2.json').read_text(encoding='utf-8'))
+          )
+          seal = HoldoutSeal.model_validate(
+              json.loads((root / 'soa-alpha-golden-v0.2.holdout-seal.json').read_text(encoding='utf-8'))
+          )
+          assert Counter(case.partition for case in manifest.cases) == {
+              'development': 9,
+              'validation': 9,
+              'holdout': 9,
+          }
+          assert verify_holdout_seal(manifest, seal)
+          assert seal.holdout_sha256 == '1f3e42cc6f1c66ce4136c89a208426e02d9456296c31054fe6e43ff0a3f4f98c'
+          PY
+
+      - name: Enforce no-provider no-live execution boundary
+        shell: bash
+        run: |
+          set -euo pipefail
+          targets=(
+            packages/python-runtime/src/soaiacore_runtime/candidate_eval.py
+            packages/python-runtime/tests/test_alpha_g3c1_candidate_bridge.py
+          )
+          ! grep -E -i 'postgresql://|client_secret|api[_-]?key|sk-proj-|az[[:space:]]+(group|network|containerapp|postgres)|terraform[[:space:]]+(apply|destroy)|Microsoft\.App/jobs/start' "${targets[@]}"
+          ! grep -E -i 'requests\.(get|post|put|patch|delete)|httpx\.(get|post|put|patch|delete)|subprocess\.(run|Popen)|os\.system|urllib\.request' "${targets[@]}"
+
+      - name: Record deterministic G3C1 gate
+        run: |
+          echo 'G3C1_CANDIDATE_TRACE_BRIDGE=PASS'
+          echo 'CANDIDATE_ORACLE_SEPARATION=true'
+          echo 'EXPECTED_FIELDS_EXPOSED=false'
+          echo 'G3C1_ALLOWED_PARTITIONS=development,validation'
+          echo 'HOLDOUT_EXECUTION=false'
+          echo 'STRUCTURED_QUALITY_SIGNALS=true'
+          echo 'CANDIDATE_IDENTITY_RECEIPT=true'
+          echo 'EXTERNAL_PROVIDER_CALLS=0'
+          echo 'G3_QUALITY_PASS_CLAIMED=false'
+          echo 'AZURE_MUTATION=false'
+          echo 'TERRAFORM_EXECUTION=false'
+          echo 'LIVE_DATABASE_MUTATION=false'
+          echo 'SCHEMA_MIGRATION=false'
+          echo 'R2_R3_ACTION_EXECUTION=false'

--- a/packages/python-runtime/src/soaiacore_runtime/candidate_eval.py
+++ b/packages/python-runtime/src/soaiacore_runtime/candidate_eval.py
@@ -210,12 +210,29 @@ def execute_g3c1_candidate_dataset(
     )
 
 
+def _validated_trace_ref(trace: dict[str, Any]) -> dict[str, str]:
+    trace_sha = trace.get("trace_sha256")
+    if not isinstance(trace_sha, str) or len(trace_sha) != 64:
+        raise ValueError("candidate trace digest is missing or malformed")
+    trace_body = {key: value for key, value in trace.items() if key != "trace_sha256"}
+    if sha256_json(trace_body) != trace_sha:
+        raise ValueError("candidate trace digest mismatch")
+    if trace.get("candidate_call_count") != 1:
+        raise ValueError("candidate trace must represent exactly one invocation")
+    if trace.get("holdout_executed") is not False:
+        raise ValueError("candidate trace indicates Holdout execution")
+    return {
+        "golden_case_id": str(trace.get("golden_case_id", "")),
+        "trace_sha256": trace_sha,
+    }
+
+
 def candidate_trace_receipt(
     *,
     traces: tuple[dict[str, Any], ...],
     expected_identity: CandidateIdentity,
 ) -> dict[str, Any]:
-    """Create a deterministic pre-Holdout receipt bound to one candidate identity."""
+    """Create a deterministic pre-Holdout receipt bound to identity and trace digests."""
 
     if not traces:
         raise ValueError("candidate trace receipt requires at least one trace")
@@ -229,7 +246,13 @@ def candidate_trace_receipt(
     if any(trace.get("oracle_fields_exposed") is not False for trace in traces):
         raise ValueError("candidate/oracle separation not proven")
 
-    case_ids = [str(trace.get("golden_case_id", "")) for trace in traces]
+    trace_refs = tuple(
+        sorted(
+            (_validated_trace_ref(trace) for trace in traces),
+            key=lambda item: item["golden_case_id"],
+        )
+    )
+    case_ids = [item["golden_case_id"] for item in trace_refs]
     if not all(case_ids) or len(case_ids) != len(set(case_ids)):
         raise ValueError("candidate trace IDs must be unique and non-empty")
 
@@ -242,11 +265,12 @@ def candidate_trace_receipt(
             "validation": counts["validation"],
             "holdout": 0,
         },
-        "candidate_call_count": sum(int(trace.get("candidate_call_count", 0)) for trace in traces),
+        "candidate_call_count": len(traces),
         "external_provider_calls": 0,
         "oracle_fields_exposed": False,
         "holdout_executed": False,
         "structured_quality_signals": True,
         "g3_quality_pass_claimed": False,
+        "trace_refs": trace_refs,
     }
     return {**body, "receipt_sha256": sha256_json(body)}

--- a/packages/python-runtime/src/soaiacore_runtime/candidate_eval.py
+++ b/packages/python-runtime/src/soaiacore_runtime/candidate_eval.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, Literal, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .cognitive_loop import (
+    CognitiveInvocationRequest,
+    CognitiveMessage,
+    CognitiveOutput,
+    ContextBundle,
+    EpistemicClass,
+    OutputDisposition,
+    evaluate_cognitive_output,
+)
+from .golden_eval import GoldenCase
+from .hashing import sha256_json
+
+
+CandidateExecutionMode = Literal["SYNTHETIC", "REPLAY", "LIVE"]
+MemoryAdmissionDecision = Literal["ADMIT", "REJECT", "DEFER"]
+_G3C1_ALLOWED_PARTITIONS = frozenset({"development", "validation"})
+
+
+class CandidateIdentity(BaseModel):
+    """Identity recorded for a candidate without embedding credentials or authority."""
+
+    model_config = ConfigDict(frozen=True)
+    provider: str = Field(min_length=1)
+    model_id: str = Field(min_length=1)
+    profile_version: str = Field(min_length=1)
+    adapter_version: str = Field(min_length=1)
+    execution_mode: CandidateExecutionMode
+
+
+class CandidateStructuredOutput(BaseModel):
+    """Provider-neutral structured result used to build a governed evaluation trace."""
+
+    model_config = ConfigDict(frozen=True)
+    content: str = Field(min_length=1)
+    epistemic_class: EpistemicClass
+    disposition: OutputDisposition
+    claims: tuple[str, ...] = ()
+    evidence_refs: tuple[str, ...] = ()
+    provenance_refs: tuple[str, ...] = ()
+    contradictions_predicted: tuple[str, ...] = ()
+    memory_admission_decision: MemoryAdmissionDecision | None = None
+    decision_state: str | None = None
+    tool_name: str | None = None
+    material_effect: bool = False
+
+
+class CandidateAdapter(Protocol):
+    """Candidate boundary. It receives runtime input/context, never Golden oracle fields."""
+
+    @property
+    def identity(self) -> CandidateIdentity: ...
+
+    def invoke(
+        self,
+        request: CognitiveInvocationRequest,
+        context: ContextBundle,
+    ) -> CandidateStructuredOutput: ...
+
+
+def build_candidate_request(
+    *,
+    case: GoldenCase,
+    context: ContextBundle,
+) -> CognitiveInvocationRequest:
+    """Build candidate-visible input without exposing Golden expected/oracle fields."""
+
+    if case.project_scope != context.project_scope:
+        raise ValueError("candidate case/context project_scope mismatch")
+    seed = {
+        "project_scope": case.project_scope,
+        "question": case.question,
+        "cutoff_time": case.cutoff_time.isoformat(),
+        "context_refs": context.context_refs,
+    }
+    return CognitiveInvocationRequest(
+        invocation_id=f"g3c-candidate-{sha256_json(seed)[:24]}",
+        task_class="golden_quality_candidate",
+        messages=(CognitiveMessage(role="user", content=case.question),),
+        context_refs=context.context_refs,
+        tool_contracts=(),
+        output_schema="soa-candidate-structured-output/0.1",
+        reasoning_budget="alpha-evaluation",
+        latency_class="offline-evaluation",
+        privacy_class="GOVERNED_PRIVATE",
+        max_cost=0.0,
+        model_constraints={"evaluation_contract": "g3c-candidate/0.1"},
+        trace_context={"evaluation_contract": "g3c-candidate/0.1"},
+    )
+
+
+def _candidate_output_to_cognitive_output(
+    *,
+    request: CognitiveInvocationRequest,
+    result: CandidateStructuredOutput,
+) -> CognitiveOutput:
+    seed = {
+        "invocation_id": request.invocation_id,
+        "result": result.model_dump(mode="json"),
+    }
+    return CognitiveOutput(
+        output_id=f"cout-{sha256_json(seed)[:24]}",
+        content=result.content,
+        epistemic_class=result.epistemic_class,
+        disposition=result.disposition,
+        evidence_refs=result.evidence_refs,
+        provenance_refs=result.provenance_refs,
+        tool_name=result.tool_name,
+        material_effect=result.material_effect,
+    )
+
+
+def _critical_provenance_refs(result: CandidateStructuredOutput) -> tuple[str, ...]:
+    ordered = list(result.provenance_refs)
+    ordered.extend(f"evidence:{ref}" for ref in result.evidence_refs)
+    return tuple(dict.fromkeys(ordered))
+
+
+def execute_g3c1_candidate_case(
+    *,
+    case: GoldenCase,
+    context: ContextBundle,
+    adapter: CandidateAdapter,
+) -> dict[str, Any]:
+    """Execute one pre-Holdout G3C1 candidate case and capture a deterministic trace.
+
+    G3C1 deliberately has no Holdout override. Enabling Holdout requires a new,
+    separately authorized G3C implementation change.
+    """
+
+    if case.partition not in _G3C1_ALLOWED_PARTITIONS:
+        raise ValueError("G3C1 holdout execution is forbidden")
+    if adapter.identity.execution_mode != "SYNTHETIC":
+        raise ValueError("G3C1 permits SYNTHETIC candidate execution only")
+
+    request = build_candidate_request(case=case, context=context)
+    result = adapter.invoke(request, context)
+    output = _candidate_output_to_cognitive_output(request=request, result=result)
+    policy = evaluate_cognitive_output(output)
+
+    output_body = output.model_dump(mode="json")
+    output_body["claims"] = list(result.claims)
+    body: dict[str, Any] = {
+        "golden_case_id": case.golden_case_id,
+        "partition": case.partition,
+        "candidate": adapter.identity.model_dump(mode="json"),
+        "invocation_id": request.invocation_id,
+        "project_scope": context.project_scope,
+        "valid_at": context.valid_at.isoformat(),
+        "recorded_at": context.recorded_at.isoformat(),
+        "context_refs": list(context.context_refs),
+        "output": output_body,
+        "policy": {
+            "action": policy.action.value,
+            "canonical_write_allowed": policy.canonical_write_allowed,
+            "material_action_executed": policy.material_action_executed,
+            "reason_codes": list(policy.reason_codes),
+        },
+        "quality_signals": {
+            "critical_provenance_refs": list(_critical_provenance_refs(result)),
+            "contradictions_predicted": list(result.contradictions_predicted),
+            "memory_admission_decision": result.memory_admission_decision,
+            "decision_state": result.decision_state,
+            "schema_valid": True,
+        },
+        "candidate_call_count": 1,
+        "external_provider_calls": 0,
+        "oracle_fields_exposed": False,
+        "holdout_executed": False,
+    }
+    return {**body, "trace_sha256": sha256_json(body)}
+
+
+def execute_g3c1_candidate_dataset(
+    *,
+    cases: tuple[GoldenCase, ...],
+    contexts_by_case_id: dict[str, ContextBundle],
+    adapter: CandidateAdapter,
+) -> tuple[dict[str, Any], ...]:
+    """Execute exact development/validation coverage for a synthetic G3C1 candidate."""
+
+    case_ids = [case.golden_case_id for case in cases]
+    if len(case_ids) != len(set(case_ids)):
+        raise ValueError("duplicate golden_case_id in G3C1 candidate input")
+    if not cases:
+        raise ValueError("G3C1 candidate dataset cannot be empty")
+    if any(case.partition not in _G3C1_ALLOWED_PARTITIONS for case in cases):
+        raise ValueError("G3C1 dataset contains a forbidden Holdout case")
+
+    expected = set(case_ids)
+    observed = set(contexts_by_case_id)
+    missing = sorted(expected - observed)
+    extra = sorted(observed - expected)
+    if missing or extra:
+        raise ValueError(f"G3C1 context coverage mismatch; missing={missing}, extra={extra}")
+
+    return tuple(
+        execute_g3c1_candidate_case(
+            case=case,
+            context=contexts_by_case_id[case.golden_case_id],
+            adapter=adapter,
+        )
+        for case in cases
+    )
+
+
+def candidate_trace_receipt(
+    *,
+    traces: tuple[dict[str, Any], ...],
+    expected_identity: CandidateIdentity,
+) -> dict[str, Any]:
+    """Create a deterministic pre-Holdout receipt bound to one candidate identity."""
+
+    if not traces:
+        raise ValueError("candidate trace receipt requires at least one trace")
+    identities = {sha256_json(trace.get("candidate", {})) for trace in traces}
+    if identities != {sha256_json(expected_identity.model_dump(mode="json"))}:
+        raise ValueError("candidate identity drift across traces")
+    if any(trace.get("partition") not in _G3C1_ALLOWED_PARTITIONS for trace in traces):
+        raise ValueError("candidate trace receipt contains Holdout execution")
+    if any(int(trace.get("external_provider_calls", 0)) != 0 for trace in traces):
+        raise ValueError("G3C1 external provider calls are forbidden")
+    if any(trace.get("oracle_fields_exposed") is not False for trace in traces):
+        raise ValueError("candidate/oracle separation not proven")
+
+    case_ids = [str(trace.get("golden_case_id", "")) for trace in traces]
+    if not all(case_ids) or len(case_ids) != len(set(case_ids)):
+        raise ValueError("candidate trace IDs must be unique and non-empty")
+
+    counts = Counter(str(trace["partition"]) for trace in traces)
+    body = {
+        "candidate": expected_identity.model_dump(mode="json"),
+        "case_count": len(traces),
+        "partition_counts": {
+            "development": counts["development"],
+            "validation": counts["validation"],
+            "holdout": 0,
+        },
+        "candidate_call_count": sum(int(trace.get("candidate_call_count", 0)) for trace in traces),
+        "external_provider_calls": 0,
+        "oracle_fields_exposed": False,
+        "holdout_executed": False,
+        "structured_quality_signals": True,
+        "g3_quality_pass_claimed": False,
+    }
+    return {**body, "receipt_sha256": sha256_json(body)}

--- a/packages/python-runtime/tests/test_alpha_g3c1_candidate_bridge.py
+++ b/packages/python-runtime/tests/test_alpha_g3c1_candidate_bridge.py
@@ -195,7 +195,7 @@ def test_candidate_trace_maps_structured_signals_after_candidate_returns():
     assert observation.epistemic_label_correct is True
 
 
-def test_dataset_execution_is_exact_dev_validation_only_and_receipt_binds_identity():
+def test_dataset_execution_is_exact_dev_validation_only_and_receipt_binds_identity_and_traces():
     cases = (
         _case("DEV-1", "development"),
         _case("VAL-1", "validation"),
@@ -223,7 +223,25 @@ def test_dataset_execution_is_exact_dev_validation_only_and_receipt_binds_identi
     assert receipt["holdout_executed"] is False
     assert receipt["structured_quality_signals"] is True
     assert receipt["g3_quality_pass_claimed"] is False
+    assert receipt["trace_refs"] == (
+        {"golden_case_id": "DEV-1", "trace_sha256": traces[0]["trace_sha256"]},
+        {"golden_case_id": "VAL-1", "trace_sha256": traces[1]["trace_sha256"]},
+    )
     assert len(receipt["receipt_sha256"]) == 64
+
+
+def test_candidate_receipt_rejects_trace_tampering():
+    adapter = RecordingAdapter()
+    trace = execute_g3c1_candidate_case(
+        case=_case("DEV-TAMPER", "development"),
+        context=_context(),
+        adapter=adapter,
+    )
+    tampered = dict(trace)
+    tampered["output"] = {**trace["output"], "content": "tampered after execution"}
+
+    with pytest.raises(ValueError, match="trace digest mismatch"):
+        candidate_trace_receipt(traces=(tampered,), expected_identity=adapter.identity)
 
 
 def test_dataset_execution_rejects_incomplete_context_coverage():

--- a/packages/python-runtime/tests/test_alpha_g3c1_candidate_bridge.py
+++ b/packages/python-runtime/tests/test_alpha_g3c1_candidate_bridge.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from soaiacore_runtime.candidate_eval import (
+    CandidateIdentity,
+    CandidateStructuredOutput,
+    candidate_trace_receipt,
+    execute_g3c1_candidate_case,
+    execute_g3c1_candidate_dataset,
+)
+from soaiacore_runtime.cognitive_loop import (
+    CognitiveInvocationRequest,
+    ContextBundle,
+    EpistemicClass,
+    OutputDisposition,
+)
+from soaiacore_runtime.golden_eval import GoldenCase
+from soaiacore_runtime.quality_eval import GoldenDatasetManifest
+from soaiacore_runtime.quality_runner import quality_observation_from_trace
+
+
+ROOT = Path(__file__).resolve().parents[1]
+V02_MANIFEST_PATH = ROOT / "golden" / "soa-alpha-golden-v0.2.json"
+NOW = datetime(2026, 9, 7, 18, 0, tzinfo=timezone.utc)
+
+
+def _identity(*, mode: str = "SYNTHETIC") -> CandidateIdentity:
+    return CandidateIdentity(
+        provider="SYNTHETIC",
+        model_id="g3c1-fixture-model",
+        profile_version="g3c1-profile/0.1",
+        adapter_version="candidate-bridge/0.1",
+        execution_mode=mode,
+    )
+
+
+def _context(scope: str = "SOAiaCore") -> ContextBundle:
+    return ContextBundle(
+        project_scope=scope,
+        valid_at=NOW,
+        recorded_at=NOW,
+        memory=(),
+        evidence_refs=("synthetic:dev",),
+        session_items=(),
+    )
+
+
+def _case(
+    case_id: str,
+    partition: str,
+    *,
+    question: str = "What is the governed state?",
+) -> GoldenCase:
+    return GoldenCase(
+        golden_case_id=case_id,
+        project_scope="SOAiaCore",
+        question=question,
+        cutoff_time=NOW,
+        allowed_evidence_refs=("synthetic:dev",),
+        expected_epistemic_class=EpistemicClass.CONFIRMED_CONTEXT,
+        expected_claims=("expected claim",),
+        expected_decision_state="ADMIT",
+        contradictions_expected=("C-1",),
+        required_provenance=("synthetic:dev",),
+        partition=partition,
+    )
+
+
+class RecordingAdapter:
+    def __init__(
+        self,
+        *,
+        identity: CandidateIdentity | None = None,
+        result: CandidateStructuredOutput | None = None,
+    ) -> None:
+        self._identity = identity or _identity()
+        self._result = result or CandidateStructuredOutput(
+            content="The governed state is confirmed by the supplied context.",
+            epistemic_class=EpistemicClass.CONFIRMED_CONTEXT,
+            disposition=OutputDisposition.CLAIM_PROPOSAL,
+            claims=("governed state confirmed",),
+            evidence_refs=("synthetic:dev",),
+            provenance_refs=("evidence:synthetic:dev",),
+            contradictions_predicted=("C-1",),
+            memory_admission_decision="ADMIT",
+            decision_state="ADMIT",
+        )
+        self.requests: list[CognitiveInvocationRequest] = []
+        self.call_count = 0
+
+    @property
+    def identity(self) -> CandidateIdentity:
+        return self._identity
+
+    def invoke(
+        self,
+        request: CognitiveInvocationRequest,
+        context: ContextBundle,
+    ) -> CandidateStructuredOutput:
+        assert context.project_scope == "SOAiaCore"
+        self.requests.append(request)
+        self.call_count += 1
+        return self._result
+
+
+def test_candidate_request_excludes_golden_oracle_fields():
+    sentinel = "ORACLE_SENTINEL_MUST_NOT_REACH_CANDIDATE"
+    case = GoldenCase(
+        golden_case_id="DEV-ORACLE-SEPARATION",
+        project_scope="SOAiaCore",
+        question="Answer from the supplied runtime context only.",
+        cutoff_time=NOW,
+        allowed_evidence_refs=("synthetic:dev",),
+        forbidden_future_refs=(sentinel,),
+        expected_epistemic_class=EpistemicClass.CONFIRMED_CONTEXT,
+        expected_claims=(sentinel,),
+        expected_decision_state=sentinel,
+        contradictions_expected=(sentinel,),
+        required_provenance=(sentinel,),
+        forbidden_tool_classes=(sentinel,),
+        notes=sentinel,
+        partition="development",
+    )
+    adapter = RecordingAdapter()
+
+    trace = execute_g3c1_candidate_case(case=case, context=_context(), adapter=adapter)
+
+    assert adapter.call_count == 1
+    serialized = json.dumps(adapter.requests[0].model_dump(mode="json"), sort_keys=True)
+    assert sentinel not in serialized
+    assert "expected_claims" not in serialized
+    assert "expected_decision_state" not in serialized
+    assert "contradictions_expected" not in serialized
+    assert "required_provenance" not in serialized
+    assert "forbidden_future_refs" not in serialized
+    assert trace["oracle_fields_exposed"] is False
+    assert trace["external_provider_calls"] == 0
+    assert trace["holdout_executed"] is False
+
+
+def test_g3c1_rejects_holdout_before_candidate_invocation():
+    adapter = RecordingAdapter()
+    with pytest.raises(ValueError, match="holdout execution is forbidden"):
+        execute_g3c1_candidate_case(
+            case=_case("HOLD-1", "holdout"),
+            context=_context(),
+            adapter=adapter,
+        )
+    assert adapter.call_count == 0
+
+
+def test_g3c1_rejects_non_synthetic_candidate_before_invocation():
+    adapter = RecordingAdapter(identity=_identity(mode="LIVE"))
+    with pytest.raises(ValueError, match="SYNTHETIC candidate execution only"):
+        execute_g3c1_candidate_case(
+            case=_case("DEV-LIVE", "development"),
+            context=_context(),
+            adapter=adapter,
+        )
+    assert adapter.call_count == 0
+
+
+def test_candidate_trace_maps_structured_signals_after_candidate_returns():
+    case = _case("DEV-SIGNALS", "development")
+    adapter = RecordingAdapter()
+
+    trace = execute_g3c1_candidate_case(case=case, context=_context(), adapter=adapter)
+    observation = quality_observation_from_trace(case=case, trace=trace)
+
+    assert trace["candidate"] == _identity().model_dump(mode="json")
+    assert trace["quality_signals"] == {
+        "critical_provenance_refs": ["evidence:synthetic:dev"],
+        "contradictions_predicted": ["C-1"],
+        "memory_admission_decision": "ADMIT",
+        "decision_state": "ADMIT",
+        "schema_valid": True,
+    }
+    assert observation.temporal_correct is True
+    assert observation.critical_provenance_claimed == 1
+    assert observation.critical_provenance_correct == 1
+    assert observation.contradictions_expected == 1
+    assert observation.contradictions_predicted == 1
+    assert observation.contradictions_true_positive == 1
+    assert observation.memory_admissions_predicted == 1
+    assert observation.memory_admissions_true_positive == 1
+    assert observation.decision_reconstruction_expected is True
+    assert observation.decision_reconstruction_correct is True
+    assert observation.schema_valid is True
+    assert observation.project_scope_correct is True
+    assert observation.epistemic_label_correct is True
+
+
+def test_dataset_execution_is_exact_dev_validation_only_and_receipt_binds_identity():
+    cases = (
+        _case("DEV-1", "development"),
+        _case("VAL-1", "validation"),
+    )
+    contexts = {case.golden_case_id: _context() for case in cases}
+    adapter = RecordingAdapter()
+
+    traces = execute_g3c1_candidate_dataset(
+        cases=cases,
+        contexts_by_case_id=contexts,
+        adapter=adapter,
+    )
+    receipt = candidate_trace_receipt(traces=traces, expected_identity=adapter.identity)
+
+    assert adapter.call_count == 2
+    assert receipt["case_count"] == 2
+    assert receipt["partition_counts"] == {
+        "development": 1,
+        "validation": 1,
+        "holdout": 0,
+    }
+    assert receipt["candidate_call_count"] == 2
+    assert receipt["external_provider_calls"] == 0
+    assert receipt["oracle_fields_exposed"] is False
+    assert receipt["holdout_executed"] is False
+    assert receipt["structured_quality_signals"] is True
+    assert receipt["g3_quality_pass_claimed"] is False
+    assert len(receipt["receipt_sha256"]) == 64
+
+
+def test_dataset_execution_rejects_incomplete_context_coverage():
+    cases = (
+        _case("DEV-1", "development"),
+        _case("VAL-1", "validation"),
+    )
+    adapter = RecordingAdapter()
+    with pytest.raises(ValueError, match="context coverage mismatch"):
+        execute_g3c1_candidate_dataset(
+            cases=cases,
+            contexts_by_case_id={"DEV-1": _context()},
+            adapter=adapter,
+        )
+    assert adapter.call_count == 0
+
+
+def test_public_v02_commitment_exposes_partition_index_not_payload():
+    raw = json.loads(V02_MANIFEST_PATH.read_text(encoding="utf-8"))
+    manifest = GoldenDatasetManifest.model_validate(raw)
+
+    assert len(manifest.cases) == 27
+    assert sum(case.partition == "development" for case in manifest.cases) == 9
+    assert sum(case.partition == "validation" for case in manifest.cases) == 9
+    assert sum(case.partition == "holdout" for case in manifest.cases) == 9
+    assert all(
+        set(item) == {"golden_case_id", "partition", "content_sha256"}
+        for item in raw["cases"]
+    )
+    assert not any("question" in item or "expected_claims" in item for item in raw["cases"])


### PR DESCRIPTION
## G3C1 Measurement / Candidate Boundary

Implements the R1-authorized G3C1 candidate-adapter/trace bridge on exact baseline `main@619eddff97b67d5dfbd633f24eec78eb6512f048`.

### Scope
- Add provider-neutral `CandidateAdapter` boundary and structured candidate output contract.
- Build candidate-visible `CognitiveInvocationRequest` without Golden `expected_*`, contradiction oracle, required provenance, future refs, notes, or forbidden-tool oracle fields.
- Convert candidate output into governed cognitive output + policy decision, then emit structured `quality_signals` only after candidate invocation.
- Record candidate identity (`provider`, `model_id`, `profile_version`, `adapter_version`, execution mode), call count and deterministic receipt.
- Permit G3C1 execution only for `development|validation` and only in `SYNTHETIC` mode.
- Reject Holdout before adapter invocation; there is intentionally no Holdout override in G3C1.
- Add regression tests across G3A, G3C0 and Alpha cognitive-loop contracts.

### Immutable boundaries
- `soa-alpha-golden-v0.1` manifest/seal unchanged.
- `soa-alpha-golden-v0.2` manifest/seal unchanged.
- No private dataset payload added to GitHub.
- No real Holdout evaluation.
- No external provider calls or credentials.
- No Azure, Terraform, A2 live, migration/schema, R2/R3 material action.

### Governance
This PR is intentionally **DRAFT**. It does not authorize READY/merge and does not claim `G3 Quality PASS`.

Authorized exclusions remain HOLD: real Holdout, provider execution, READY/merge, Azure, Terraform, live A2, migrations/schema, R2/R3.