### PR TITLE
feat(soa-intelligence): add G3C2A provider execution boundary

### DIFF
--- a/.github/workflows/soa-intelligence-g3c2a-provider.yml
+++ b/.github/workflows/soa-intelligence-g3c2a-provider.yml
@@ -1,0 +1,137 @@
+name: SOA Intelligence G3C2A Provider Boundary
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'feat/g3c2a-provider-execution-boundary-*'
+    paths:
+      - .github/workflows/soa-intelligence-g3c2a-provider.yml
+      - packages/python-runtime/src/soaiacore_runtime/provider_eval.py
+      - packages/python-runtime/tests/test_alpha_g3c2a_provider_boundary.py
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/soa-intelligence-g3c2a-provider.yml
+      - packages/python-runtime/src/soaiacore_runtime/provider_eval.py
+      - packages/python-runtime/tests/test_alpha_g3c2a_provider_boundary.py
+
+permissions:
+  contents: read
+
+concurrency:
+  group: g3c2a-provider-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  provider-boundary:
+    name: G3C2A Provider A no-outbound gate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 12
+
+    steps:
+      - name: Check out exact commit
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          fetch-depth: 0
+
+      - name: Enforce exact G3C2A R1 file boundary and immutable datasets
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin main --depth=1
+          changed="$(git diff --name-only origin/main...HEAD)"
+          printf '%s\n' "$changed"
+          test -n "$changed"
+          allowed='^(\.github/workflows/soa-intelligence-g3c2a-provider\.yml|packages/python-runtime/src/soaiacore_runtime/provider_eval\.py|packages/python-runtime/tests/test_alpha_g3c2a_provider_boundary\.py)$'
+          if printf '%s\n' "$changed" | grep -Ev "$allowed"; then
+            echo 'G3C2A_R1_SCOPE_VIOLATION=true'
+            exit 1
+          fi
+          test "$(git rev-parse HEAD:packages/python-runtime/golden/soa-alpha-golden-v0.1.json)" = '14996ad98169cc388312e237b18f00c6e34c83f2'
+          test "$(git rev-parse HEAD:packages/python-runtime/golden/soa-alpha-golden-v0.1.holdout-seal.json)" = '969a2040f52ccc721a50ad455b6f6ce5bc5e8cd8'
+          test "$(git rev-parse HEAD:packages/python-runtime/golden/soa-alpha-golden-v0.2.json)" = '76783ecb77cf19b69617c6d5c9b5ca879856634b'
+          test "$(git rev-parse HEAD:packages/python-runtime/golden/soa-alpha-golden-v0.2.holdout-seal.json)" = '6b7b3f9f9b24caaa0ed5961308707f53b457d264'
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: 3.12.14
+
+      - name: Compile G3C2A boundary
+        run: |
+          python -m py_compile \
+            packages/python-runtime/src/soaiacore_runtime/provider_eval.py \
+            packages/python-runtime/tests/test_alpha_g3c2a_provider_boundary.py
+
+      - name: Install frozen runtime
+        run: |
+          python -m pip install --disable-pip-version-check --no-cache-dir uv==0.12.5
+          uv sync --frozen
+
+      - name: Run G3C2A and Alpha regression tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}/packages/python-runtime/src
+          OPENAI_API_KEY: runtime-ci-placeholder-not-a-real-key
+        run: |
+          uv run --frozen pytest -q \
+            packages/python-runtime/tests/test_alpha_g3a_quality.py \
+            packages/python-runtime/tests/test_alpha_g3c0_integrity.py \
+            packages/python-runtime/tests/test_alpha_g3c1_candidate_bridge.py \
+            packages/python-runtime/tests/test_alpha_g3c2a_provider_boundary.py \
+            packages/python-runtime/tests/test_alpha_cognitive_loop_contract.py
+
+      - name: Prove Holdout and outbound transport remain unreachable
+        shell: bash
+        run: |
+          set -euo pipefail
+          targets=(
+            packages/python-runtime/src/soaiacore_runtime/provider_eval.py
+            packages/python-runtime/tests/test_alpha_g3c2a_provider_boundary.py
+          )
+          ! grep -E -i 'requests\.(get|post|put|patch|delete)|httpx\.(get|post|put|patch|delete)|urllib\.request|socket\.|subprocess\.(run|Popen)|os\.system' "${targets[@]}"
+          ! grep -E -i 'sk-proj-|sk-[A-Za-z0-9_-]{20,}' "${targets[@]}"
+          ! grep -E -i 'terraform[[:space:]]+(apply|destroy)|az[[:space:]]+(group|network|containerapp|postgres)|Microsoft\.App/jobs/start|postgresql://' "${targets[@]}"
+          grep -q '_G3C2A_ALLOWED_PARTITIONS = frozenset({"development", "validation"})' packages/python-runtime/src/soaiacore_runtime/provider_eval.py
+          grep -q 'G3C2A Holdout execution is forbidden' packages/python-runtime/src/soaiacore_runtime/provider_eval.py
+          grep -q 'G3C2A forbids external provider transport' packages/python-runtime/src/soaiacore_runtime/provider_eval.py
+
+      - name: Validate Provider A boundary invariants
+        env:
+          PYTHONPATH: ${{ github.workspace }}/packages/python-runtime/src
+          OPENAI_API_KEY: runtime-ci-placeholder-not-a-real-key
+        run: |
+          uv run --frozen python - <<'PY'
+          from soaiacore_runtime.provider_eval import ProviderAConfig
+
+          config = ProviderAConfig(
+              model_id='provider-a-fixture-model',
+              profile_version='g3c2a-profile/0.1',
+              adapter_version='provider-a-boundary/0.1',
+          )
+          identity = config.identity()
+          assert identity.provider == 'openai'
+          assert identity.execution_mode == 'REPLAY'
+          assert config.credential_env == 'OPENAI_API_KEY'
+          assert config.max_attempts <= 3
+          PY
+
+      - name: Record deterministic G3C2A gate
+        run: |
+          echo 'G3C2A_PROVIDER_BOUNDARY=PASS'
+          echo 'PROVIDER_A=openai'
+          echo 'EXECUTION_MODE=REPLAY'
+          echo 'CREDENTIAL_SOURCE=runtime_env_only'
+          echo 'CANDIDATE_ORACLE_SEPARATION=true'
+          echo 'ALLOWED_PARTITIONS=development,validation'
+          echo 'HOLDOUT_EXECUTION=false'
+          echo 'TOOLS_ENABLED=false'
+          echo 'EXTERNAL_PROVIDER_CALLS=0'
+          echo 'PRIVATE_PAYLOAD_COMMITTED_TO_GITHUB=false'
+          echo 'G3_QUALITY_PASS_CLAIMED=false'
+          echo 'AZURE_MUTATION=false'
+          echo 'TERRAFORM_EXECUTION=false'
+          echo 'LIVE_DATABASE_MUTATION=false'
+          echo 'SCHEMA_MIGRATION=false'
+          echo 'R2_R3_ACTION_EXECUTION=false'

--- a/packages/python-runtime/src/soaiacore_runtime/provider_eval.py
+++ b/packages/python-runtime/src/soaiacore_runtime/provider_eval.py
@@ -1,0 +1,391 @@
+from __future__ import annotations
+
+import os
+from collections import Counter
+from collections.abc import Mapping
+from typing import Any, Literal, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .candidate_eval import (
+    CandidateIdentity,
+    CandidateStructuredOutput,
+    MemoryAdmissionDecision,
+    build_candidate_request,
+)
+from .cognitive_loop import (
+    CognitiveInvocationRequest,
+    CognitiveOutput,
+    ContextBundle,
+    evaluate_cognitive_output,
+)
+from .golden_eval import GoldenCase
+from .hashing import sha256_json
+
+
+_G3C2A_ALLOWED_PARTITIONS = frozenset({"development", "validation"})
+ProviderAExecutionMode = Literal["REPLAY"]
+
+
+class ProviderTransportError(RuntimeError):
+    """Retryable failure raised by a provider transport implementation."""
+
+
+class ProviderExecutionError(RuntimeError):
+    """Fail-closed provider boundary error."""
+
+
+class ProviderATransport(Protocol):
+    """Injectable Provider A transport.
+
+    G3C2A accepts only transports that explicitly report external=False. A later,
+    separately authorized increment may add a real outbound transport.
+    """
+
+    @property
+    def external(self) -> bool: ...
+
+    def send(
+        self,
+        *,
+        payload: dict[str, Any],
+        credential: str,
+    ) -> dict[str, Any]: ...
+
+
+class ProviderAConfig(BaseModel):
+    """Versioned deployment profile for the first concrete provider boundary."""
+
+    model_config = ConfigDict(frozen=True)
+
+    provider: Literal["openai"] = "openai"
+    model_id: str = Field(min_length=1)
+    profile_version: str = Field(min_length=1)
+    adapter_version: str = Field(min_length=1)
+    execution_mode: ProviderAExecutionMode = "REPLAY"
+    credential_env: str = Field(default="OPENAI_API_KEY", min_length=1)
+    max_attempts: int = Field(default=2, ge=1, le=3)
+
+    def identity(self) -> CandidateIdentity:
+        return CandidateIdentity(
+            provider=self.provider,
+            model_id=self.model_id,
+            profile_version=self.profile_version,
+            adapter_version=self.adapter_version,
+            execution_mode=self.execution_mode,
+        )
+
+
+class ProviderAAdapter:
+    """Provider A candidate adapter with an injectable, non-external G3C2A transport."""
+
+    def __init__(
+        self,
+        *,
+        config: ProviderAConfig,
+        transport: ProviderATransport,
+        environment: Mapping[str, str] | None = None,
+    ) -> None:
+        self._config = config
+        self._transport = transport
+        self._environment = environment
+        self._last_attempt_count = 0
+
+    @property
+    def identity(self) -> CandidateIdentity:
+        return self._config.identity()
+
+    @property
+    def last_attempt_count(self) -> int:
+        return self._last_attempt_count
+
+    def _credential(self) -> str:
+        environment = self._environment if self._environment is not None else os.environ
+        value = environment.get(self._config.credential_env, "")
+        if not value.strip():
+            raise ProviderExecutionError(
+                f"provider credential missing from runtime env {self._config.credential_env}"
+            )
+        return value
+
+    @staticmethod
+    def _context_payload(context: ContextBundle) -> dict[str, Any]:
+        return {
+            "project_scope": context.project_scope,
+            "valid_at": context.valid_at.isoformat(),
+            "recorded_at": context.recorded_at.isoformat(),
+            "memory": [dict(item) for item in context.memory],
+            "evidence_refs": list(context.evidence_refs),
+            "session_items": [
+                {
+                    "item_id": item.item_id,
+                    "project_scope": item.project_scope,
+                    "payload": dict(item.payload),
+                    "sensitivity": item.sensitivity,
+                    "epistemic_class": item.epistemic_class.value,
+                    "created_at": item.created_at.isoformat(),
+                    "expires_at": item.expires_at.isoformat(),
+                }
+                for item in context.session_items
+            ],
+        }
+
+    def _wire_payload(
+        self,
+        *,
+        request: CognitiveInvocationRequest,
+        context: ContextBundle,
+    ) -> dict[str, Any]:
+        return {
+            "provider": self._config.provider,
+            "model": self._config.model_id,
+            "profile_version": self._config.profile_version,
+            "messages": [message.model_dump(mode="json") for message in request.messages],
+            "context": self._context_payload(context),
+            "response_contract": {
+                "schema": request.output_schema,
+                "required": ["content", "epistemic_class", "disposition"],
+                "optional": [
+                    "claims",
+                    "evidence_refs",
+                    "provenance_refs",
+                    "contradictions_predicted",
+                    "memory_admission_decision",
+                    "decision_state",
+                    "tool_name",
+                    "material_effect",
+                ],
+            },
+            "tools": [],
+            "tool_choice": "none",
+            "trace": {
+                "invocation_id": request.invocation_id,
+                "evaluation_contract": "g3c-provider-a/0.1",
+            },
+        }
+
+    def invoke(
+        self,
+        request: CognitiveInvocationRequest,
+        context: ContextBundle,
+    ) -> CandidateStructuredOutput:
+        if self._transport.external:
+            raise ProviderExecutionError(
+                "G3C2A forbids external provider transport; R2 provider execution is required"
+            )
+        if request.tool_contracts:
+            raise ProviderExecutionError("G3C2A provider benchmark forbids tool contracts")
+
+        credential = self._credential()
+        payload = self._wire_payload(request=request, context=context)
+        self._last_attempt_count = 0
+        response: dict[str, Any] | None = None
+        last_error: ProviderTransportError | None = None
+
+        for attempt in range(1, self._config.max_attempts + 1):
+            self._last_attempt_count = attempt
+            try:
+                response = self._transport.send(payload=payload, credential=credential)
+                break
+            except ProviderTransportError as exc:
+                last_error = exc
+
+        if response is None:
+            raise ProviderExecutionError(
+                f"provider transport exhausted {self._last_attempt_count} attempt(s)"
+            ) from last_error
+        if not isinstance(response, dict):
+            raise ProviderExecutionError("provider transport returned a non-object payload")
+
+        try:
+            result = CandidateStructuredOutput.model_validate(response)
+        except Exception as exc:
+            raise ProviderExecutionError("provider structured output validation failed") from exc
+
+        if result.tool_name is not None or result.material_effect:
+            raise ProviderExecutionError("provider candidate attempted a forbidden tool/material effect")
+        return result
+
+
+def _to_cognitive_output(
+    *,
+    request: CognitiveInvocationRequest,
+    result: CandidateStructuredOutput,
+) -> CognitiveOutput:
+    seed = {
+        "invocation_id": request.invocation_id,
+        "result": result.model_dump(mode="json"),
+    }
+    return CognitiveOutput(
+        output_id=f"cout-{sha256_json(seed)[:24]}",
+        content=result.content,
+        epistemic_class=result.epistemic_class,
+        disposition=result.disposition,
+        evidence_refs=result.evidence_refs,
+        provenance_refs=result.provenance_refs,
+        tool_name=None,
+        material_effect=False,
+    )
+
+
+def _critical_provenance_refs(result: CandidateStructuredOutput) -> tuple[str, ...]:
+    ordered = list(result.provenance_refs)
+    ordered.extend(f"evidence:{ref}" for ref in result.evidence_refs)
+    return tuple(dict.fromkeys(ordered))
+
+
+def execute_g3c2a_provider_case(
+    *,
+    case: GoldenCase,
+    context: ContextBundle,
+    adapter: ProviderAAdapter,
+) -> dict[str, Any]:
+    """Capture one Provider A replay trace without external calls or Holdout access."""
+
+    if case.partition not in _G3C2A_ALLOWED_PARTITIONS:
+        raise ProviderExecutionError("G3C2A Holdout execution is forbidden")
+    if adapter.identity.execution_mode != "REPLAY":
+        raise ProviderExecutionError("G3C2A permits REPLAY execution only")
+    if case.project_scope != context.project_scope:
+        raise ProviderExecutionError("G3C2A case/context project_scope mismatch")
+
+    request = build_candidate_request(case=case, context=context)
+    result = adapter.invoke(request, context)
+    output = _to_cognitive_output(request=request, result=result)
+    policy = evaluate_cognitive_output(output)
+
+    output_body = output.model_dump(mode="json")
+    output_body["claims"] = list(result.claims)
+    body: dict[str, Any] = {
+        "golden_case_id": case.golden_case_id,
+        "partition": case.partition,
+        "candidate": adapter.identity.model_dump(mode="json"),
+        "invocation_id": request.invocation_id,
+        "project_scope": context.project_scope,
+        "valid_at": context.valid_at.isoformat(),
+        "recorded_at": context.recorded_at.isoformat(),
+        "context_refs": list(context.context_refs),
+        "output": output_body,
+        "policy": {
+            "action": policy.action.value,
+            "canonical_write_allowed": policy.canonical_write_allowed,
+            "material_action_executed": policy.material_action_executed,
+            "reason_codes": list(policy.reason_codes),
+        },
+        "quality_signals": {
+            "critical_provenance_refs": list(_critical_provenance_refs(result)),
+            "contradictions_predicted": list(result.contradictions_predicted),
+            "memory_admission_decision": result.memory_admission_decision,
+            "decision_state": result.decision_state,
+            "schema_valid": True,
+        },
+        "candidate_call_count": 1,
+        "transport_attempt_count": adapter.last_attempt_count,
+        "external_provider_calls": 0,
+        "oracle_fields_exposed": False,
+        "holdout_executed": False,
+        "tools_enabled": False,
+        "provider_boundary_version": "g3c-provider-a/0.1",
+    }
+    return {**body, "trace_sha256": sha256_json(body)}
+
+
+def execute_g3c2a_provider_dataset(
+    *,
+    cases: tuple[GoldenCase, ...],
+    contexts_by_case_id: dict[str, ContextBundle],
+    adapter: ProviderAAdapter,
+) -> tuple[dict[str, Any], ...]:
+    """Execute exact development/validation coverage through the mock Provider A boundary."""
+
+    if not cases:
+        raise ProviderExecutionError("G3C2A provider dataset cannot be empty")
+    case_ids = [case.golden_case_id for case in cases]
+    if len(case_ids) != len(set(case_ids)):
+        raise ProviderExecutionError("duplicate golden_case_id in G3C2A input")
+    if any(case.partition not in _G3C2A_ALLOWED_PARTITIONS for case in cases):
+        raise ProviderExecutionError("G3C2A dataset contains a forbidden Holdout case")
+
+    expected = set(case_ids)
+    observed = set(contexts_by_case_id)
+    missing = sorted(expected - observed)
+    extra = sorted(observed - expected)
+    if missing or extra:
+        raise ProviderExecutionError(
+            f"G3C2A context coverage mismatch; missing={missing}, extra={extra}"
+        )
+
+    return tuple(
+        execute_g3c2a_provider_case(
+            case=case,
+            context=contexts_by_case_id[case.golden_case_id],
+            adapter=adapter,
+        )
+        for case in cases
+    )
+
+
+def _validated_trace_ref(trace: dict[str, Any]) -> dict[str, str]:
+    trace_sha = trace.get("trace_sha256")
+    if not isinstance(trace_sha, str) or len(trace_sha) != 64:
+        raise ProviderExecutionError("provider trace digest is missing or malformed")
+    body = {key: value for key, value in trace.items() if key != "trace_sha256"}
+    if sha256_json(body) != trace_sha:
+        raise ProviderExecutionError("provider trace digest mismatch")
+    if trace.get("external_provider_calls") != 0:
+        raise ProviderExecutionError("G3C2A trace indicates an external provider call")
+    if trace.get("holdout_executed") is not False:
+        raise ProviderExecutionError("G3C2A trace indicates Holdout execution")
+    if trace.get("oracle_fields_exposed") is not False:
+        raise ProviderExecutionError("candidate/oracle separation not proven")
+    return {
+        "golden_case_id": str(trace.get("golden_case_id", "")),
+        "trace_sha256": trace_sha,
+    }
+
+
+def provider_trace_receipt(
+    *,
+    traces: tuple[dict[str, Any], ...],
+    expected_identity: CandidateIdentity,
+) -> dict[str, Any]:
+    """Deterministic G3C2A receipt bound to candidate identity and trace digests."""
+
+    if not traces:
+        raise ProviderExecutionError("provider trace receipt requires at least one trace")
+    expected_identity_sha = sha256_json(expected_identity.model_dump(mode="json"))
+    identities = {sha256_json(trace.get("candidate", {})) for trace in traces}
+    if identities != {expected_identity_sha}:
+        raise ProviderExecutionError("provider identity drift across traces")
+    if any(trace.get("partition") not in _G3C2A_ALLOWED_PARTITIONS for trace in traces):
+        raise ProviderExecutionError("provider receipt contains Holdout execution")
+
+    trace_refs = tuple(
+        sorted(
+            (_validated_trace_ref(trace) for trace in traces),
+            key=lambda item: item["golden_case_id"],
+        )
+    )
+    case_ids = [item["golden_case_id"] for item in trace_refs]
+    if not all(case_ids) or len(case_ids) != len(set(case_ids)):
+        raise ProviderExecutionError("provider trace IDs must be unique and non-empty")
+
+    counts = Counter(str(trace["partition"]) for trace in traces)
+    body = {
+        "candidate": expected_identity.model_dump(mode="json"),
+        "case_count": len(traces),
+        "partition_counts": {
+            "development": counts["development"],
+            "validation": counts["validation"],
+            "holdout": 0,
+        },
+        "candidate_call_count": len(traces),
+        "transport_attempt_count": sum(int(trace["transport_attempt_count"]) for trace in traces),
+        "external_provider_calls": 0,
+        "oracle_fields_exposed": False,
+        "holdout_executed": False,
+        "tools_enabled": False,
+        "g3_quality_pass_claimed": False,
+        "trace_refs": trace_refs,
+    }
+    return {**body, "receipt_sha256": sha256_json(body)}

--- a/packages/python-runtime/tests/test_alpha_g3c2a_provider_boundary.py
+++ b/packages/python-runtime/tests/test_alpha_g3c2a_provider_boundary.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from soaiacore_runtime.cognitive_loop import (
+    ContextBundle,
+    EpistemicClass,
+    OutputDisposition,
+)
+from soaiacore_runtime.golden_eval import GoldenCase
+from soaiacore_runtime.provider_eval import (
+    ProviderAAdapter,
+    ProviderAConfig,
+    ProviderExecutionError,
+    ProviderTransportError,
+    execute_g3c2a_provider_case,
+    execute_g3c2a_provider_dataset,
+    provider_trace_receipt,
+)
+from soaiacore_runtime.quality_runner import quality_observation_from_trace
+
+
+NOW = datetime(2026, 9, 8, 18, 0, tzinfo=timezone.utc)
+API_KEY = "runtime-secret-not-a-real-key"
+
+
+def _config(*, max_attempts: int = 2) -> ProviderAConfig:
+    return ProviderAConfig(
+        model_id="provider-a-fixture-model",
+        profile_version="g3c2a-profile/0.1",
+        adapter_version="provider-a-boundary/0.1",
+        max_attempts=max_attempts,
+    )
+
+
+def _context(scope: str = "SOAiaCore") -> ContextBundle:
+    return ContextBundle(
+        project_scope=scope,
+        valid_at=NOW,
+        recorded_at=NOW,
+        memory=(
+            {
+                "memory_id": "M-DEV-1",
+                "project_scope": scope,
+                "claim": "Synthetic governed context only.",
+            },
+        ),
+        evidence_refs=("synthetic:dev",),
+        session_items=(),
+    )
+
+
+def _case(
+    case_id: str,
+    partition: str = "development",
+    *,
+    question: str = "What is the governed state?",
+) -> GoldenCase:
+    return GoldenCase(
+        golden_case_id=case_id,
+        project_scope="SOAiaCore",
+        question=question,
+        cutoff_time=NOW,
+        allowed_evidence_refs=("synthetic:dev",),
+        expected_epistemic_class=EpistemicClass.CONFIRMED_CONTEXT,
+        expected_claims=("governed state confirmed",),
+        expected_decision_state="ADMIT",
+        contradictions_expected=("C-1",),
+        required_provenance=("synthetic:dev",),
+        partition=partition,
+    )
+
+
+def _good_response() -> dict[str, Any]:
+    return {
+        "content": "The governed state is confirmed by the supplied context.",
+        "epistemic_class": EpistemicClass.CONFIRMED_CONTEXT.value,
+        "disposition": OutputDisposition.CLAIM_PROPOSAL.value,
+        "claims": ["governed state confirmed"],
+        "evidence_refs": ["synthetic:dev"],
+        "provenance_refs": ["evidence:synthetic:dev"],
+        "contradictions_predicted": ["C-1"],
+        "memory_admission_decision": "ADMIT",
+        "decision_state": "ADMIT",
+        "tool_name": None,
+        "material_effect": False,
+    }
+
+
+class FakeTransport:
+    def __init__(
+        self,
+        *,
+        responses: list[dict[str, Any] | Exception] | None = None,
+        external: bool = False,
+    ) -> None:
+        self._external = external
+        self.responses = list(responses or [_good_response()])
+        self.payloads: list[dict[str, Any]] = []
+        self.credentials: list[str] = []
+        self.call_count = 0
+
+    @property
+    def external(self) -> bool:
+        return self._external
+
+    def send(self, *, payload: dict[str, Any], credential: str) -> dict[str, Any]:
+        self.call_count += 1
+        self.payloads.append(payload)
+        self.credentials.append(credential)
+        if not self.responses:
+            raise AssertionError("fake transport exhausted")
+        value = self.responses.pop(0)
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+
+def _adapter(
+    transport: FakeTransport,
+    *,
+    environment: dict[str, str] | None = None,
+    max_attempts: int = 2,
+) -> ProviderAAdapter:
+    return ProviderAAdapter(
+        config=_config(max_attempts=max_attempts),
+        transport=transport,
+        environment=environment if environment is not None else {"OPENAI_API_KEY": API_KEY},
+    )
+
+
+def test_provider_a_request_excludes_oracle_and_secret_from_trace():
+    sentinel = "ORACLE_SENTINEL_MUST_NOT_REACH_PROVIDER"
+    case = GoldenCase(
+        golden_case_id="DEV-PROVIDER-ORACLE-SEPARATION",
+        project_scope="SOAiaCore",
+        question="Answer only from supplied runtime context.",
+        cutoff_time=NOW,
+        allowed_evidence_refs=("synthetic:dev",),
+        forbidden_future_refs=(sentinel,),
+        expected_epistemic_class=EpistemicClass.CONFIRMED_CONTEXT,
+        expected_claims=(sentinel,),
+        expected_decision_state=sentinel,
+        contradictions_expected=(sentinel,),
+        required_provenance=(sentinel,),
+        forbidden_tool_classes=(sentinel,),
+        notes=sentinel,
+        partition="development",
+    )
+    transport = FakeTransport()
+    adapter = _adapter(transport)
+
+    trace = execute_g3c2a_provider_case(case=case, context=_context(), adapter=adapter)
+
+    assert transport.call_count == 1
+    assert transport.credentials == [API_KEY]
+    wire = json.dumps(transport.payloads[0], sort_keys=True)
+    serialized_trace = json.dumps(trace, sort_keys=True)
+    assert sentinel not in wire
+    assert "expected_claims" not in wire
+    assert "expected_decision_state" not in wire
+    assert "contradictions_expected" not in wire
+    assert "required_provenance" not in wire
+    assert "forbidden_future_refs" not in wire
+    assert API_KEY not in wire
+    assert API_KEY not in serialized_trace
+    assert trace["external_provider_calls"] == 0
+    assert trace["oracle_fields_exposed"] is False
+    assert trace["holdout_executed"] is False
+    assert trace["tools_enabled"] is False
+
+
+def test_g3c2a_rejects_holdout_before_transport_invocation():
+    transport = FakeTransport()
+    adapter = _adapter(transport)
+    with pytest.raises(ProviderExecutionError, match="Holdout execution is forbidden"):
+        execute_g3c2a_provider_case(
+            case=_case("HOLD-PROVIDER", "holdout"),
+            context=_context(),
+            adapter=adapter,
+        )
+    assert transport.call_count == 0
+
+
+def test_g3c2a_rejects_external_transport_before_outbound_call():
+    transport = FakeTransport(external=True)
+    adapter = _adapter(transport)
+    with pytest.raises(ProviderExecutionError, match="forbids external provider transport"):
+        execute_g3c2a_provider_case(
+            case=_case("DEV-EXTERNAL-BLOCK"),
+            context=_context(),
+            adapter=adapter,
+        )
+    assert transport.call_count == 0
+
+
+def test_provider_credential_must_come_from_runtime_env():
+    transport = FakeTransport()
+    adapter = _adapter(transport, environment={})
+    with pytest.raises(ProviderExecutionError, match="credential missing from runtime env"):
+        execute_g3c2a_provider_case(
+            case=_case("DEV-NO-CREDENTIAL"),
+            context=_context(),
+            adapter=adapter,
+        )
+    assert transport.call_count == 0
+
+
+def test_retry_is_bounded_and_receipted_without_external_calls():
+    transport = FakeTransport(
+        responses=[ProviderTransportError("temporary"), _good_response()]
+    )
+    adapter = _adapter(transport, max_attempts=2)
+
+    trace = execute_g3c2a_provider_case(
+        case=_case("DEV-RETRY"),
+        context=_context(),
+        adapter=adapter,
+    )
+
+    assert transport.call_count == 2
+    assert trace["transport_attempt_count"] == 2
+    assert trace["candidate_call_count"] == 1
+    assert trace["external_provider_calls"] == 0
+
+
+def test_retry_exhaustion_fails_closed():
+    transport = FakeTransport(
+        responses=[ProviderTransportError("one"), ProviderTransportError("two")]
+    )
+    adapter = _adapter(transport, max_attempts=2)
+    with pytest.raises(ProviderExecutionError, match="exhausted 2 attempt"):
+        execute_g3c2a_provider_case(
+            case=_case("DEV-RETRY-FAIL"),
+            context=_context(),
+            adapter=adapter,
+        )
+    assert transport.call_count == 2
+
+
+def test_malformed_structured_output_fails_closed():
+    transport = FakeTransport(responses=[{"content": "missing required enums"}])
+    adapter = _adapter(transport)
+    with pytest.raises(ProviderExecutionError, match="structured output validation failed"):
+        execute_g3c2a_provider_case(
+            case=_case("DEV-MALFORMED"),
+            context=_context(),
+            adapter=adapter,
+        )
+
+
+def test_tool_or_material_effect_request_is_rejected():
+    response = _good_response()
+    response["tool_name"] = "dangerous_tool"
+    response["material_effect"] = True
+    transport = FakeTransport(responses=[response])
+    adapter = _adapter(transport)
+    with pytest.raises(ProviderExecutionError, match="forbidden tool/material effect"):
+        execute_g3c2a_provider_case(
+            case=_case("DEV-TOOL-BLOCK"),
+            context=_context(),
+            adapter=adapter,
+        )
+
+
+def test_provider_trace_produces_objective_quality_signals():
+    case = _case("DEV-QUALITY")
+    transport = FakeTransport()
+    adapter = _adapter(transport)
+
+    trace = execute_g3c2a_provider_case(case=case, context=_context(), adapter=adapter)
+    observation = quality_observation_from_trace(case=case, trace=trace)
+
+    assert trace["candidate"]["provider"] == "openai"
+    assert trace["candidate"]["execution_mode"] == "REPLAY"
+    assert observation.temporal_correct is True
+    assert observation.critical_provenance_claimed == 1
+    assert observation.critical_provenance_correct == 1
+    assert observation.contradictions_expected == 1
+    assert observation.contradictions_predicted == 1
+    assert observation.contradictions_true_positive == 1
+    assert observation.memory_admissions_predicted == 1
+    assert observation.memory_admissions_true_positive == 1
+    assert observation.decision_reconstruction_expected is True
+    assert observation.decision_reconstruction_correct is True
+    assert observation.schema_valid is True
+    assert observation.project_scope_correct is True
+    assert observation.epistemic_label_correct is True
+
+
+def test_dataset_coverage_and_receipt_bind_identity_and_trace_digests():
+    cases = (
+        _case("DEV-PROVIDER-1", "development"),
+        _case("VAL-PROVIDER-1", "validation"),
+    )
+    contexts = {case.golden_case_id: _context() for case in cases}
+    transport = FakeTransport(responses=[_good_response(), _good_response()])
+    adapter = _adapter(transport)
+
+    traces = execute_g3c2a_provider_dataset(
+        cases=cases,
+        contexts_by_case_id=contexts,
+        adapter=adapter,
+    )
+    receipt = provider_trace_receipt(traces=traces, expected_identity=adapter.identity)
+
+    assert transport.call_count == 2
+    assert receipt["case_count"] == 2
+    assert receipt["partition_counts"] == {
+        "development": 1,
+        "validation": 1,
+        "holdout": 0,
+    }
+    assert receipt["candidate_call_count"] == 2
+    assert receipt["external_provider_calls"] == 0
+    assert receipt["holdout_executed"] is False
+    assert receipt["g3_quality_pass_claimed"] is False
+    assert len(receipt["trace_refs"]) == 2
+    assert len(receipt["receipt_sha256"]) == 64
+
+
+def test_dataset_rejects_incomplete_context_coverage():
+    cases = (
+        _case("DEV-PROVIDER-1", "development"),
+        _case("VAL-PROVIDER-1", "validation"),
+    )
+    transport = FakeTransport()
+    adapter = _adapter(transport)
+    with pytest.raises(ProviderExecutionError, match="context coverage mismatch"):
+        execute_g3c2a_provider_dataset(
+            cases=cases,
+            contexts_by_case_id={"DEV-PROVIDER-1": _context()},
+            adapter=adapter,
+        )
+    assert transport.call_count == 0
+
+
+def test_provider_receipt_rejects_trace_tampering():
+    transport = FakeTransport()
+    adapter = _adapter(transport)
+    trace = execute_g3c2a_provider_case(
+        case=_case("DEV-PROVIDER-TAMPER"),
+        context=_context(),
+        adapter=adapter,
+    )
+    tampered = dict(trace)
+    tampered["output"] = {**trace["output"], "content": "tampered"}
+
+    with pytest.raises(ProviderExecutionError, match="trace digest mismatch"):
+        provider_trace_receipt(traces=(tampered,), expected_identity=adapter.identity)


### PR DESCRIPTION
## G3C2A Provider Execution Boundary

Implements the R1-authorized Provider A execution boundary on exact baseline `main@94214bcd864f48674eed5740bd1d175d3c66c0e9`.

### Scope
- Preserve G3C1 unchanged.
- Add versioned Provider A (`openai`) adapter/transport contract without adding a provider SDK.
- Load the provider credential only from runtime environment (`OPENAI_API_KEY`); credentials are excluded from traces and receipts.
- Restrict G3C2A to `development|validation` and `REPLAY` mode.
- Hard-reject Holdout before transport invocation.
- Hard-reject any transport reporting `external=true`; G3C2A CI performs `external_provider_calls=0`.
- Preserve candidate/oracle separation through the existing provider-neutral request builder.
- Disable tools and reject tool/material-effect outputs.
- Add bounded retry, malformed-output, missing-credential, identity/trace digest and tamper fail-closed tests.
- Add deterministic CI scope guards and v0.1/v0.2 immutable blob checks.

### Validation before PR
- G3C2A Provider A no-outbound gate run `34272234851`: SUCCESS on exact head `24c3182fca1e1889587d6cd78154e622c1139e5d`.
- Final branch compare: exactly 3 added files; ahead 3 / behind 0.

### Immutable boundaries
- No real provider call or outbound transport.
- No private dataset payload committed to GitHub.
- No Holdout execution.
- No G3 Quality PASS claim.
- No Azure, Terraform, A2 live, migration/schema, or R2/R3 material action.

### Governance
This PR is intentionally **DRAFT**. READY/merge is not authorized by G3C2A R1.

A separate R2 gate is required before any real Provider A execution or private payload transmission to a third party.