### PR TITLE
feat(soa-intelligence): governed G3C2B2 live execution workflow

### DIFF
--- a/.github/workflows/soa-intelligence-g3c2b1-single-shot-harness.yml
+++ b/.github/workflows/soa-intelligence-g3c2b1-single-shot-harness.yml
@@ -47,7 +47,7 @@ jobs:
           changed="$(git diff --name-only origin/main...HEAD)"
           printf '%s\n' "$changed"
           test -n "$changed"
-          allowed='^(\.github/workflows/soa-intelligence-g3c2b1-single-shot-harness\.yml|packages/python-runtime/src/soaiacore_runtime/provider_live_smoke\.py|packages/python-runtime/tests/test_alpha_g3c2b1_single_shot_harness\.py)$'
+          allowed='^(\.github/workflows/soa-intelligence-g3c2b1-single-shot-harness\.yml|\.github/workflows/soa-intelligence-g3c2b2-governed-live-smoke\.yml|packages/python-runtime/src/soaiacore_runtime/provider_live_smoke\.py|packages/python-runtime/tests/test_alpha_g3c2b1_single_shot_harness\.py)$'
           if printf '%s\n' "$changed" | grep -Ev "$allowed"; then
             echo 'G3C2B1_R1_SCOPE_VIOLATION=true'
             exit 1

--- a/.github/workflows/soa-intelligence-g3c2b2-governed-live-smoke.yml
+++ b/.github/workflows/soa-intelligence-g3c2b2-governed-live-smoke.yml
@@ -1,0 +1,189 @@
+name: SOA Intelligence G3C2B2 Governed Live Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_main_sha:
+        description: Exact protected main commit SHA authorized for this one-shot execution
+        required: true
+        type: string
+      r2_authority_ref:
+        description: Non-empty exact R2 authority reference
+        required: true
+        type: string
+      one_call_confirmation:
+        description: Type I_UNDERSTAND_ONE_PUBLIC_SYNTHETIC_CALL_ONLY exactly
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: g3c2b2-governed-live-smoke
+  cancel-in-progress: false
+
+jobs:
+  governed-live-smoke:
+    name: G3C2B2 one PUBLIC synthetic Provider A call
+    runs-on: ubuntu-24.04
+    timeout-minutes: 12
+    env:
+      EXPECTED_MAIN_SHA: ${{ inputs.expected_main_sha }}
+      R2_AUTHORITY_REF: ${{ inputs.r2_authority_ref }}
+      ONE_CALL_CONFIRMATION: ${{ inputs.one_call_confirmation }}
+      PYTHONPATH: ${{ github.workspace }}/packages/python-runtime/src
+
+    steps:
+      - name: Check out authoritative main
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Fail closed on authority, identity, and fixed-case drift
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$GITHUB_EVENT_NAME" = workflow_dispatch
+          test "$GITHUB_REF_NAME" = main
+          test -n "$R2_AUTHORITY_REF"
+          test "$ONE_CALL_CONFIRMATION" = I_UNDERSTAND_ONE_PUBLIC_SYNTHETIC_CALL_ONLY
+          printf '%s' "$EXPECTED_MAIN_SHA" | grep -Eq '^[0-9a-f]{40}$'
+          git fetch origin main --depth=1
+          test "$(git rev-parse HEAD)" = "$EXPECTED_MAIN_SHA"
+          test "$(git rev-parse origin/main)" = "$EXPECTED_MAIN_SHA"
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: 3.12.14
+
+      - name: Install frozen runtime
+        run: |
+          python -m pip install --disable-pip-version-check --no-cache-dir uv==0.12.5
+          uv sync --frozen
+
+      - name: Prepare fixed execution intent without credentials or provider I/O
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run --frozen python -m soaiacore_runtime.provider_live_smoke preflight \
+            --expected-main-sha "$EXPECTED_MAIN_SHA" \
+            --r2-authority-ref "$R2_AUTHORITY_REF" \
+            --workflow-run-id "$GITHUB_RUN_ID" \
+            --one-call-confirmation "$ONE_CALL_CONFIRMATION" \
+            --intent-out "$RUNNER_TEMP/g3c2b2-intent.json" \
+            > "$RUNNER_TEMP/g3c2b2-preflight.json"
+          OUT="$RUNNER_TEMP/g3c2b2-preflight.json" uv run --frozen python - <<'PY'
+          import json
+          import os
+          from soaiacore_runtime.provider_live_smoke import (
+              SMOKE_CASE_ID,
+              SMOKE_PROFILE_VERSION,
+          )
+
+          data = json.load(open(os.environ["OUT"], encoding="utf-8"))
+          assert data["golden_case_id"] == SMOKE_CASE_ID
+          assert data["partition"] == "development"
+          assert data["synthetic_only"] is True
+          assert data["sensitivity"] == "PUBLIC"
+          assert data["single_shot"] is True
+          assert data["max_attempts"] == 1
+          assert data["holdout_allowed"] is False
+          assert data["full_dataset_evaluation"] is False
+          assert data["g3_quality_pass_claimed"] is False
+          assert data["external_provider_calls"] == 0
+          assert data["credential_read"] is False
+          assert data["outbound_executed"] is False
+          candidate = data["candidate"]
+          assert candidate == {
+              "provider": "openai",
+              "model_id": "gpt-5.6-sol",
+              "profile_version": SMOKE_PROFILE_VERSION,
+              "adapter_version": "provider-a-live-boundary/0.1",
+              "execution_mode": "LIVE",
+          }
+          intent = data["execution_intent"]
+          assert intent["expected_main_sha"] == os.environ["EXPECTED_MAIN_SHA"]
+          assert intent["r2_authority_ref"] == os.environ["R2_AUTHORITY_REF"]
+          assert intent["case_id"] == SMOKE_CASE_ID
+          assert intent["provider"] == "openai"
+          assert intent["model"] == "gpt-5.6-sol"
+          assert intent["profile_version"] == SMOKE_PROFILE_VERSION
+          assert intent["workflow_run_id"] == os.environ["GITHUB_RUN_ID"]
+          assert len(intent["payload_sha256"]) == 64
+          assert len(intent["intent_sha256"]) == 64
+          PY
+
+      - name: Claim non-replay execution intent in Issue 67
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          intent_sha="$(python -c 'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["execution_intent"]["intent_sha256"])' "$RUNNER_TEMP/g3c2b2-intent.json")"
+          if gh api --paginate "repos/$GITHUB_REPOSITORY/issues/67/comments?per_page=100" --jq '.[].body' | grep -Fq "G3C2B2_INTENT_SHA256=$intent_sha"; then
+            echo 'G3C2B2 replay detected for execution intent'
+            exit 1
+          fi
+          claim_body="G3C2B2_EXECUTION_INTENT_CLAIMED\n\nG3C2B2_INTENT_SHA256=$intent_sha\nR2_AUTHORITY_REF=$R2_AUTHORITY_REF\nEXPECTED_MAIN_SHA=$EXPECTED_MAIN_SHA\nWORKFLOW_RUN_ID=$GITHUB_RUN_ID\nCASE_ID=G3C2B1-SYNTHETIC-LIVE-SMOKE-001\nEXTERNAL_PROVIDER_CALLS=0_BEFORE_EXECUTION"
+          gh api "repos/$GITHUB_REPOSITORY/issues/67/comments" --method POST -f body="$claim_body" > /dev/null
+
+      - name: Execute exactly one fixed synthetic Provider A call
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          SOAIACORE_G3C2B0_NO_OUTBOUND: '0'
+          SOAIACORE_G3C2B1_ALLOW_OUTBOUND: '1'
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run --frozen python -m soaiacore_runtime.provider_live_smoke execute \
+            --r2-authority-ref "$R2_AUTHORITY_REF" \
+            --expected-main-sha "$EXPECTED_MAIN_SHA" \
+            --workflow-run-id "$GITHUB_RUN_ID" \
+            --one-call-confirmation "$ONE_CALL_CONFIRMATION" \
+            --intent-file "$RUNNER_TEMP/g3c2b2-intent.json" \
+            --intent-lock "$RUNNER_TEMP/g3c2b2-intent.lock" \
+            --receipt-out "$RUNNER_TEMP/g3c2b2-receipt.json"
+
+      - name: Validate and publish the safe canonical receipt
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          RECEIPT="$RUNNER_TEMP/g3c2b2-receipt.json" uv run --frozen python - <<'PY'
+          import json
+          import os
+
+          data = json.load(open(os.environ["RECEIPT"], encoding="utf-8"))
+          receipt = data["single_shot_receipt"]
+          assert receipt["main_sha"] == os.environ["EXPECTED_MAIN_SHA"]
+          assert receipt["r2_authority_ref"] == os.environ["R2_AUTHORITY_REF"]
+          assert receipt["case_id"] == "G3C2B1-SYNTHETIC-LIVE-SMOKE-001"
+          assert receipt["provider"] == "openai"
+          assert receipt["model"] == "gpt-5.6-sol"
+          assert receipt["external_provider_calls"] == 1
+          assert receipt["transport_attempt_count"] == 1
+          assert receipt["Holdout"] is False
+          assert receipt["full_dataset"] is False
+          assert receipt["G3_quality_pass"] is False
+          for key in (
+              "provider_request_id",
+              "client_request_id",
+              "provider_response_id",
+              "payload_sha256",
+              "trace_sha256",
+              "receipt_sha256",
+              "execution_intent_sha256",
+          ):
+              assert isinstance(receipt[key], str) and receipt[key]
+          assert len(receipt["payload_sha256"]) == 64
+          assert len(receipt["trace_sha256"]) == 64
+          assert len(receipt["receipt_sha256"]) == 64
+          PY
+          receipt_json="$(python -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1], encoding="utf-8"))["single_shot_receipt"], sort_keys=True, indent=2))' "$RUNNER_TEMP/g3c2b2-receipt.json")"
+          body="G3C2B2-LIVE-SMOKE-CANONICAL-RECEIPT\n\n\`\`\`json\n$receipt_json\n\`\`\`"
+          gh api "repos/$GITHUB_REPOSITORY/issues/67/comments" --method POST -f body="$body" > /dev/null

--- a/packages/python-runtime/src/soaiacore_runtime/provider_live_smoke.py
+++ b/packages/python-runtime/src/soaiacore_runtime/provider_live_smoke.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 from collections.abc import Mapping
 from datetime import datetime, timezone
 from pathlib import Path
@@ -34,6 +35,8 @@ SMOKE_OUTBOUND_PERMIT_ENV = "SOAIACORE_G3C2B1_ALLOW_OUTBOUND"
 SMOKE_MAX_OUTPUT_TOKENS = 512
 SMOKE_MAX_ATTEMPTS = 1
 SMOKE_TIMEOUT_SECONDS = 30.0
+SMOKE_REQUIRED_CONFIRMATION = "I_UNDERSTAND_ONE_PUBLIC_SYNTHETIC_CALL_ONLY"
+_MAIN_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 
 
 class SingleShotSmokeError(RuntimeError):
@@ -128,7 +131,75 @@ def _smoke_spec() -> dict[str, Any]:
     }
 
 
-def preflight_single_shot_smoke() -> dict[str, Any]:
+def _execution_intent(
+    *,
+    expected_main_sha: str,
+    r2_authority_ref: str,
+    workflow_run_id: str,
+    one_call_confirmation: str,
+    payload_sha256: str,
+    config: ProviderALiveConfig,
+) -> dict[str, Any]:
+    main_sha = expected_main_sha.strip().lower()
+    authority = r2_authority_ref.strip()
+    run_id = workflow_run_id.strip()
+    if not _MAIN_SHA_PATTERN.fullmatch(main_sha):
+        raise SingleShotSmokeError("expected main SHA is not a 40-character lowercase commit SHA")
+    if not authority:
+        raise SingleShotSmokeError("execution intent requires a non-empty R2 authority ref")
+    if not run_id:
+        raise SingleShotSmokeError("execution intent requires a non-empty workflow run identity")
+    if one_call_confirmation.strip() != SMOKE_REQUIRED_CONFIRMATION:
+        raise SingleShotSmokeError("one-call confirmation literal is invalid")
+    body = {
+        "r2_authority_ref": authority,
+        "expected_main_sha": main_sha,
+        "case_id": SMOKE_CASE_ID,
+        "provider": config.provider,
+        "model": config.model_id,
+        "profile_version": config.profile_version,
+        "payload_sha256": payload_sha256,
+        "workflow_run_id": run_id,
+        "one_call_confirmation": SMOKE_REQUIRED_CONFIRMATION,
+    }
+    return {**body, "intent_sha256": sha256_json(body)}
+
+
+def _load_execution_intent(path: str) -> dict[str, Any]:
+    try:
+        raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SingleShotSmokeError("execution intent file is missing or malformed") from exc
+    if not isinstance(raw, dict) or not isinstance(raw.get("execution_intent"), dict):
+        raise SingleShotSmokeError("execution intent file does not contain an execution_intent object")
+    return raw["execution_intent"]
+
+
+def _claim_execution_intent(intent: dict[str, Any], lock_path: str | None) -> None:
+    if not lock_path:
+        return
+    target = Path(lock_path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        fd = os.open(target, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    except FileExistsError as exc:
+        raise SingleShotSmokeError("execution intent replay detected; lock already exists") from exc
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(json.dumps({"intent_sha256": intent["intent_sha256"]}, sort_keys=True))
+            handle.write("\n")
+    except Exception:
+        target.unlink(missing_ok=True)
+        raise
+
+
+def preflight_single_shot_smoke(
+    *,
+    expected_main_sha: str | None = None,
+    r2_authority_ref: str | None = None,
+    workflow_run_id: str | None = None,
+    one_call_confirmation: str | None = None,
+) -> dict[str, Any]:
     """Prepare the fixed synthetic request without reading credentials or opening a socket."""
 
     case = _synthetic_case()
@@ -149,6 +220,18 @@ def preflight_single_shot_smoke() -> dict[str, Any]:
         "credential_read": False,
         "outbound_executed": False,
     }
+    intent_values = (expected_main_sha, r2_authority_ref, workflow_run_id, one_call_confirmation)
+    if any(value is not None for value in intent_values):
+        if not all(value is not None for value in intent_values):
+            raise SingleShotSmokeError("execution intent requires expected SHA, authority ref, and workflow run ID")
+        body["execution_intent"] = _execution_intent(
+            expected_main_sha=expected_main_sha or "",
+            r2_authority_ref=r2_authority_ref or "",
+            workflow_run_id=workflow_run_id or "",
+            one_call_confirmation=one_call_confirmation or "",
+            payload_sha256=prepared.payload_sha256,
+            config=config,
+        )
     return {**body, "preflight_sha256": sha256_json(body)}
 
 
@@ -162,8 +245,13 @@ def _require_outbound_permit(environment: Mapping[str, str]) -> None:
 def run_single_shot_smoke(
     *,
     r2_authority_ref: str,
+    expected_main_sha: str,
+    workflow_run_id: str,
+    one_call_confirmation: str,
     http_client: ProviderAHTTPClient | None = None,
     environment: Mapping[str, str] | None = None,
+    expected_intent: dict[str, Any] | None = None,
+    intent_lock_path: str | None = None,
 ) -> dict[str, Any]:
     """Execute exactly one fixed PUBLIC synthetic Provider A call after explicit R2 gating.
 
@@ -180,6 +268,24 @@ def run_single_shot_smoke(
     _require_outbound_permit(env)
 
     config = _config()
+    prepared = prepare_g3c2b0_live_request(
+        case=_synthetic_case(),
+        context=_synthetic_context(),
+        config=config,
+        data_policy=_data_policy(),
+    )
+    intent = _execution_intent(
+        expected_main_sha=expected_main_sha,
+        r2_authority_ref=authority,
+        workflow_run_id=workflow_run_id,
+        one_call_confirmation=one_call_confirmation,
+        payload_sha256=prepared.payload_sha256,
+        config=config,
+    )
+    if expected_intent is not None and expected_intent != intent:
+        raise SingleShotSmokeError("execution intent drift or replay mismatch")
+    _claim_execution_intent(intent, intent_lock_path)
+
     client = http_client if http_client is not None else UrllibProviderAHTTPClient()
     adapter = ProviderALiveAdapter(
         config=config,
@@ -202,6 +308,9 @@ def run_single_shot_smoke(
     if trace.get("transport_attempt_count") != 1:
         raise SingleShotSmokeError("single-shot harness forbids transport retries")
 
+    if trace["payload_sha256"] != intent["payload_sha256"]:
+        raise SingleShotSmokeError("provider payload digest drift")
+
     boundary_receipt = live_provider_trace_receipt(
         traces=(trace,),
         expected_identity=config.identity(),
@@ -219,10 +328,22 @@ def run_single_shot_smoke(
     body = {
         **_smoke_spec(),
         "candidate": config.identity().model_dump(mode="json"),
+        "main_sha": intent["expected_main_sha"],
         "r2_authority_ref": authority,
+        "case_id": SMOKE_CASE_ID,
+        "provider": config.provider,
+        "model": config.model_id,
+        "profile_version": config.profile_version,
+        "workflow_run_id": intent["workflow_run_id"],
+        "execution_intent_sha256": intent["intent_sha256"],
         "external_provider_calls": 1,
         "transport_attempt_count": 1,
+        "Holdout": False,
+        "full_dataset": False,
+        "G3_quality_pass": False,
         "trace_ref": trace_ref,
+        "trace_sha256": trace["trace_sha256"],
+        "payload_sha256": trace["payload_sha256"],
         "provider_trace_sha256": trace["trace_sha256"],
         "provider_payload_sha256": trace["payload_sha256"],
         "boundary_receipt_sha256": boundary_receipt["receipt_sha256"],
@@ -259,21 +380,50 @@ def main(argv: list[str] | None = None) -> int:
         "preflight",
         help="prepare and hash the fixed synthetic request without credential or network access",
     )
+    preflight = subparsers.choices["preflight"]
+    preflight.add_argument("--expected-main-sha")
+    preflight.add_argument("--r2-authority-ref")
+    preflight.add_argument("--workflow-run-id")
+    preflight.add_argument("--one-call-confirmation")
+    preflight.add_argument("--intent-out")
 
     execute = subparsers.add_parser(
         "execute",
         help="execute exactly one fixed PUBLIC synthetic provider call after an R2 permit",
     )
     execute.add_argument("--r2-authority-ref", required=True)
+    execute.add_argument("--expected-main-sha", required=True)
+    execute.add_argument("--workflow-run-id", required=True)
+    execute.add_argument("--one-call-confirmation", required=True)
+    execute.add_argument("--intent-file", required=True)
+    execute.add_argument("--intent-lock", required=True)
     execute.add_argument("--receipt-out", required=True)
 
     args = parser.parse_args(argv)
     if args.command == "preflight":
-        print(json.dumps(preflight_single_shot_smoke(), sort_keys=True))
+        intent_args = {
+            "expected_main_sha": getattr(args, "expected_main_sha", None),
+            "r2_authority_ref": getattr(args, "r2_authority_ref", None),
+            "workflow_run_id": getattr(args, "workflow_run_id", None),
+            "one_call_confirmation": getattr(args, "one_call_confirmation", None),
+        }
+        result = preflight_single_shot_smoke(**intent_args)
+        intent_out = getattr(args, "intent_out", None)
+        if intent_out:
+            _write_json(intent_out, result)
+        print(json.dumps(result, sort_keys=True))
         return 0
 
     if args.command == "execute":
-        result = run_single_shot_smoke(r2_authority_ref=args.r2_authority_ref)
+        intent_file = _load_execution_intent(args.intent_file)
+        result = run_single_shot_smoke(
+            r2_authority_ref=args.r2_authority_ref,
+            expected_main_sha=args.expected_main_sha,
+            workflow_run_id=args.workflow_run_id,
+            one_call_confirmation=args.one_call_confirmation,
+            expected_intent=intent_file,
+            intent_lock_path=args.intent_lock,
+        )
         _write_json(args.receipt_out, result)
         print(
             json.dumps(

--- a/packages/python-runtime/tests/test_alpha_g3c2b1_single_shot_harness.py
+++ b/packages/python-runtime/tests/test_alpha_g3c2b1_single_shot_harness.py
@@ -10,6 +10,8 @@ from soaiacore_runtime.provider_live import (
     ProviderLiveTransportError,
 )
 from soaiacore_runtime.provider_live_smoke import (
+    SMOKE_PROFILE_VERSION,
+    SMOKE_REQUIRED_CONFIRMATION,
     SMOKE_CASE_ID,
     SMOKE_MAX_ATTEMPTS,
     SMOKE_OUTBOUND_PERMIT_ENV,
@@ -25,6 +27,9 @@ from soaiacore_runtime.provider_live_smoke import (
 
 
 API_KEY = "runtime-placeholder-not-a-real-key"
+MAIN_SHA = "eda14a940f56e2e4929c7ae108e37cceacf9a0a5"
+WORKFLOW_RUN_ID = "34299999999"
+CONFIRMATION = SMOKE_REQUIRED_CONFIRMATION
 
 
 class RecordingHTTPClient:
@@ -145,6 +150,9 @@ def test_execute_requires_exact_r2_authority_before_any_http_call():
     with pytest.raises(SingleShotSmokeError, match="exact R2 authority ref"):
         run_single_shot_smoke(
             r2_authority_ref="",
+            expected_main_sha=MAIN_SHA,
+            workflow_run_id=WORKFLOW_RUN_ID,
+            one_call_confirmation=CONFIRMATION,
             http_client=client,
             environment=_environment(),
         )
@@ -156,6 +164,9 @@ def test_execute_requires_separate_outbound_permit_before_any_http_call():
     with pytest.raises(SingleShotSmokeError, match=SMOKE_OUTBOUND_PERMIT_ENV):
         run_single_shot_smoke(
             r2_authority_ref="R2-FUTURE-SMOKE",
+            expected_main_sha=MAIN_SHA,
+            workflow_run_id=WORKFLOW_RUN_ID,
+            one_call_confirmation=CONFIRMATION,
             http_client=client,
             environment={"OPENAI_API_KEY": API_KEY},
         )
@@ -165,10 +176,16 @@ def test_execute_requires_separate_outbound_permit_before_any_http_call():
 def test_single_shot_mock_executes_exactly_once_and_receipts_are_bound():
     preflight = preflight_single_shot_smoke()
     client = RecordingHTTPClient(
-        responses=[_response(client_request_id=preflight["client_request_id"])]
+        responses=[
+            _response(client_request_id=preflight["client_request_id"]),
+            _response(client_request_id=preflight["client_request_id"]),
+        ]
     )
     result = run_single_shot_smoke(
         r2_authority_ref="R2-FUTURE-SMOKE",
+        expected_main_sha=MAIN_SHA,
+        workflow_run_id=WORKFLOW_RUN_ID,
+        one_call_confirmation=CONFIRMATION,
         http_client=client,
         environment=_environment(),
     )
@@ -219,6 +236,9 @@ def test_single_shot_forbids_retry_after_transport_failure():
     with pytest.raises(Exception, match="exhausted 1 attempt"):
         run_single_shot_smoke(
             r2_authority_ref="R2-FUTURE-SMOKE",
+            expected_main_sha=MAIN_SHA,
+            workflow_run_id=WORKFLOW_RUN_ID,
+            one_call_confirmation=CONFIRMATION,
             http_client=client,
             environment=_environment(),
         )
@@ -240,14 +260,237 @@ def test_cli_execute_cannot_start_without_outbound_permit(monkeypatch, tmp_path)
     monkeypatch.setenv("OPENAI_API_KEY", API_KEY)
     monkeypatch.setenv(SMOKE_OUTBOUND_PERMIT_ENV, "0")
     monkeypatch.setenv("SOAIACORE_G3C2B0_NO_OUTBOUND", "1")
+    intent_file = tmp_path / "intent.json"
+    intent_file.write_text(
+        json.dumps(
+            preflight_single_shot_smoke(
+                expected_main_sha=MAIN_SHA,
+                r2_authority_ref="R2-FUTURE-SMOKE",
+                workflow_run_id=WORKFLOW_RUN_ID,
+                one_call_confirmation=CONFIRMATION,
+            )
+        ),
+        encoding="utf-8",
+    )
     with pytest.raises(SingleShotSmokeError, match=SMOKE_OUTBOUND_PERMIT_ENV):
         main(
             [
                 "execute",
                 "--r2-authority-ref",
                 "R2-FUTURE-SMOKE",
+                "--expected-main-sha",
+                MAIN_SHA,
+                "--workflow-run-id",
+                WORKFLOW_RUN_ID,
+                "--one-call-confirmation",
+                CONFIRMATION,
+                "--intent-file",
+                str(intent_file),
+                "--intent-lock",
+                str(tmp_path / "intent.lock"),
                 "--receipt-out",
                 str(tmp_path / "should-not-exist.json"),
             ]
         )
     assert not (tmp_path / "should-not-exist.json").exists()
+
+
+def test_preflight_execution_intent_binds_authority_identity_payload_and_run():
+    preflight = preflight_single_shot_smoke(
+        expected_main_sha=MAIN_SHA,
+        r2_authority_ref="R2-FUTURE-SMOKE",
+        workflow_run_id=WORKFLOW_RUN_ID,
+        one_call_confirmation=CONFIRMATION,
+    )
+    intent = preflight["execution_intent"]
+
+    assert intent == {
+        "r2_authority_ref": "R2-FUTURE-SMOKE",
+        "expected_main_sha": MAIN_SHA,
+        "case_id": SMOKE_CASE_ID,
+        "provider": "openai",
+        "model": "gpt-5.6-sol",
+        "profile_version": SMOKE_PROFILE_VERSION,
+        "payload_sha256": preflight["payload_sha256"],
+        "workflow_run_id": WORKFLOW_RUN_ID,
+        "one_call_confirmation": CONFIRMATION,
+        "intent_sha256": intent["intent_sha256"],
+    }
+    assert len(intent["intent_sha256"]) == 64
+
+
+def test_preflight_rejects_wrong_main_sha_and_confirmation():
+    with pytest.raises(SingleShotSmokeError, match="40-character"):
+        preflight_single_shot_smoke(
+            expected_main_sha="not-a-main-sha",
+            r2_authority_ref="R2-FUTURE-SMOKE",
+            workflow_run_id=WORKFLOW_RUN_ID,
+            one_call_confirmation=CONFIRMATION,
+        )
+    with pytest.raises(SingleShotSmokeError, match="confirmation literal"):
+        preflight_single_shot_smoke(
+            expected_main_sha=MAIN_SHA,
+            r2_authority_ref="R2-FUTURE-SMOKE",
+            workflow_run_id=WORKFLOW_RUN_ID,
+            one_call_confirmation="I_CONFIRM_TWO_CALLS",
+        )
+
+
+def test_execute_rejects_wrong_authority_bound_to_preflight_before_http_call():
+    preflight = preflight_single_shot_smoke(
+        expected_main_sha=MAIN_SHA,
+        r2_authority_ref="R2-FUTURE-SMOKE",
+        workflow_run_id=WORKFLOW_RUN_ID,
+        one_call_confirmation=CONFIRMATION,
+    )
+    client = RecordingHTTPClient(
+        responses=[_response(client_request_id=preflight["client_request_id"])]
+    )
+    with pytest.raises(SingleShotSmokeError, match="intent drift"):
+        run_single_shot_smoke(
+            r2_authority_ref="R2-WRONG-AUTHORITY",
+            expected_main_sha=MAIN_SHA,
+            workflow_run_id=WORKFLOW_RUN_ID,
+            one_call_confirmation=CONFIRMATION,
+            http_client=client,
+            environment=_environment(),
+            expected_intent=preflight["execution_intent"],
+        )
+    assert client.calls == []
+
+
+def test_execute_rejects_replayed_intent_before_second_http_call(tmp_path):
+    preflight = preflight_single_shot_smoke(
+        expected_main_sha=MAIN_SHA,
+        r2_authority_ref="R2-FUTURE-SMOKE",
+        workflow_run_id=WORKFLOW_RUN_ID,
+        one_call_confirmation=CONFIRMATION,
+    )
+    lock = str(tmp_path / "intent.lock")
+    first_client = RecordingHTTPClient(
+        responses=[_response(client_request_id=preflight["client_request_id"])]
+    )
+    run_single_shot_smoke(
+        r2_authority_ref="R2-FUTURE-SMOKE",
+        expected_main_sha=MAIN_SHA,
+        workflow_run_id=WORKFLOW_RUN_ID,
+        one_call_confirmation=CONFIRMATION,
+        http_client=first_client,
+        environment=_environment(),
+        expected_intent=preflight["execution_intent"],
+        intent_lock_path=lock,
+    )
+
+    second_client = RecordingHTTPClient(
+        responses=[_response(client_request_id=preflight["client_request_id"])]
+    )
+    with pytest.raises(SingleShotSmokeError, match="replay"):
+        run_single_shot_smoke(
+            r2_authority_ref="R2-FUTURE-SMOKE",
+            expected_main_sha=MAIN_SHA,
+            workflow_run_id=WORKFLOW_RUN_ID,
+            one_call_confirmation=CONFIRMATION,
+            http_client=second_client,
+            environment=_environment(),
+            expected_intent=preflight["execution_intent"],
+            intent_lock_path=lock,
+        )
+    assert second_client.calls == []
+
+
+def test_execute_rejects_missing_secret_before_http_call():
+    client = RecordingHTTPClient()
+    with pytest.raises(Exception, match="credential missing"):
+        run_single_shot_smoke(
+            r2_authority_ref="R2-FUTURE-SMOKE",
+            expected_main_sha=MAIN_SHA,
+            workflow_run_id=WORKFLOW_RUN_ID,
+            one_call_confirmation=CONFIRMATION,
+            http_client=client,
+            environment={SMOKE_OUTBOUND_PERMIT_ENV: "1"},
+        )
+    assert client.calls == []
+
+
+def test_execute_rejects_model_drift_case_drift_holdout_malformed_and_tool_effect(monkeypatch):
+    preflight = preflight_single_shot_smoke()
+
+    drifted_model = _response(client_request_id=preflight["client_request_id"])
+    drifted_model.response_json["model"] = "gpt-5.5"
+    with pytest.raises(Exception, match="model identity drift"):
+        run_single_shot_smoke(
+            r2_authority_ref="R2-FUTURE-SMOKE",
+            expected_main_sha=MAIN_SHA,
+            workflow_run_id=WORKFLOW_RUN_ID,
+            one_call_confirmation=CONFIRMATION,
+            http_client=RecordingHTTPClient([drifted_model]),
+            environment=_environment(),
+        )
+
+    original_case = _synthetic_case
+    monkeypatch.setattr(
+        "soaiacore_runtime.provider_live_smoke._synthetic_case",
+        lambda: original_case().model_copy(update={"golden_case_id": "DRIFTED-CASE"}),
+    )
+    with pytest.raises(Exception, match="case identity drift"):
+        run_single_shot_smoke(
+            r2_authority_ref="R2-FUTURE-SMOKE",
+            expected_main_sha=MAIN_SHA,
+            workflow_run_id=WORKFLOW_RUN_ID,
+            one_call_confirmation=CONFIRMATION,
+            http_client=RecordingHTTPClient([_response(client_request_id=preflight["client_request_id"])]),
+            environment=_environment(),
+        )
+    monkeypatch.setattr("soaiacore_runtime.provider_live_smoke._synthetic_case", original_case)
+
+    holdout_case = original_case().model_copy(update={"partition": "holdout"})
+    monkeypatch.setattr("soaiacore_runtime.provider_live_smoke._synthetic_case", lambda: holdout_case)
+    with pytest.raises(Exception, match="Holdout"):
+        run_single_shot_smoke(
+            r2_authority_ref="R2-FUTURE-SMOKE",
+            expected_main_sha=MAIN_SHA,
+            workflow_run_id=WORKFLOW_RUN_ID,
+            one_call_confirmation=CONFIRMATION,
+            http_client=RecordingHTTPClient(),
+            environment=_environment(),
+        )
+    monkeypatch.setattr("soaiacore_runtime.provider_live_smoke._synthetic_case", original_case)
+
+    malformed = _response(client_request_id=preflight["client_request_id"])
+    malformed.response_json["output"][0]["content"][0]["text"] = "not-json"
+    with pytest.raises(Exception, match="valid JSON"):
+        run_single_shot_smoke(
+            r2_authority_ref="R2-FUTURE-SMOKE",
+            expected_main_sha=MAIN_SHA,
+            workflow_run_id=WORKFLOW_RUN_ID,
+            one_call_confirmation=CONFIRMATION,
+            http_client=RecordingHTTPClient([malformed]),
+            environment=_environment(),
+        )
+
+    tool_effect = _response(client_request_id=preflight["client_request_id"])
+    tool_effect.response_json["output"][0]["content"][0]["text"] = json.dumps(
+        {
+            "content": "Synthetic ALPHA_SMOKE state is READY.",
+            "epistemic_class": "CONFIRMED_CONTEXT",
+            "disposition": "TOOL_REQUEST",
+            "claims": [],
+            "evidence_refs": [],
+            "provenance_refs": [],
+            "contradictions_predicted": [],
+            "memory_admission_decision": "REJECT",
+            "decision_state": "READY",
+            "tool_name": "forbidden_tool",
+            "material_effect": True,
+        },
+        sort_keys=True,
+    )
+    with pytest.raises(Exception, match="tool/material effect"):
+        run_single_shot_smoke(
+            r2_authority_ref="R2-FUTURE-SMOKE",
+            expected_main_sha=MAIN_SHA,
+            workflow_run_id=WORKFLOW_RUN_ID,
+            one_call_confirmation=CONFIRMATION,
+            http_client=RecordingHTTPClient([tool_effect]),
+            environment=_environment(),
+        )


### PR DESCRIPTION
## G3C2B2 R1

Implements the exact Issue #67 authorized increment from main@eda14a940f56e2e4929c7ae108e37cceacf9a0a5.

- Adds workflow_dispatch-only governed LIVE smoke workflow.
- Requires expected_main_sha, r2_authority_ref, and exact one-call confirmation.
- Uses only fixed G3C2B1-SYNTHETIC-LIVE-SMOKE-001 (PUBLIC/development, gpt-5.6-sol, high, max_attempts=1).
- Uses only the existing GitHub Actions secret handle ${{ secrets.OPENAI_API_KEY }} in the future execution step; no key is created, read, printed, or used by R1 validation.
- Binds execution intent and receipt to authority, main SHA, fixed identity, payload digest, and workflow run ID.
- Claims the intent in Issue #67 before the call to fail closed on replay.
- R1 validation uses mocks/fakes only; external_provider_calls=0.

Validation: focused G3/Alpha suite 72 passed locally; full local integration suite requires SOAIACORE_TEST_DATABASE_URL and was not runnable here.